### PR TITLE
feat: filter nextjs

### DIFF
--- a/packages/sample-app/package.json
+++ b/packages/sample-app/package.json
@@ -7,6 +7,7 @@
     "run:decorators": "npm run build && node dist/src/sample_decorators.js",
     "run:with": "npm run build && node dist/src/sample_with.js",
     "run:prompt_mgmt": "npm run build && node dist/src/sample_prompt_mgmt.js",
+    "run:sampler": "npm run build && node dist/src/sample_sampler.js",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix"
   },

--- a/packages/sample-app/src/sample_sampler.ts
+++ b/packages/sample-app/src/sample_sampler.ts
@@ -1,0 +1,30 @@
+import * as traceloop from "@traceloop/node-server-sdk";
+import { trace, Span, context } from "@opentelemetry/api";
+import { ConsoleSpanExporter } from "@opentelemetry/sdk-trace-base";
+
+trace.getTracer("traceloop.tracer");
+
+// No spans should be printed to the console when this file runs (it should be filtered out by the sampler)
+
+const main = async () => {
+  traceloop.initialize({
+    appName: "sample_sampler",
+    apiKey: process.env.TRACELOOP_API_KEY,
+    disableBatch: true,
+    traceloopSyncEnabled: false,
+    exporter: new ConsoleSpanExporter(),
+  });
+
+  trace
+    .getTracer("traceloop.tracer")
+    .startActiveSpan(
+      "test-span",
+      { attributes: { "next.span_name": "anything" } },
+      context.active(),
+      async (span: Span) => {
+        span.end();
+      },
+    );
+};
+
+main();

--- a/packages/traceloop-sdk/src/lib/tracing/index.ts
+++ b/packages/traceloop-sdk/src/lib/tracing/index.ts
@@ -13,6 +13,7 @@ import { OpenAIInstrumentation } from "@traceloop/instrumentation-openai";
 import { SpanAttributes } from "@traceloop/ai-semantic-conventions";
 import { ASSOCATION_PROPERTIES_KEY, WORKFLOW_NAME_KEY } from "./tracing";
 import { Telemetry } from "../telemetry/telemetry";
+import { TraceloopSampler } from "./sampler";
 
 let _sdk: NodeSDK;
 let _spanProcessor: SimpleSpanProcessor | BatchSpanProcessor;
@@ -90,6 +91,7 @@ export const startTracing = (options: InitializeOptions) => {
     spanProcessor: _spanProcessor,
     traceExporter,
     instrumentations,
+    sampler: new TraceloopSampler(),
   });
 
   _sdk.start();

--- a/packages/traceloop-sdk/src/lib/tracing/sampler.ts
+++ b/packages/traceloop-sdk/src/lib/tracing/sampler.ts
@@ -1,0 +1,36 @@
+import {
+  Sampler,
+  SamplingResult,
+  SamplingDecision,
+} from "@opentelemetry/sdk-trace-base";
+import { Context, SpanKind, Attributes, Link } from "@opentelemetry/api";
+
+const FILTERED_ATTRIBUTE_KEYS = ["next.span_name"];
+
+export class TraceloopSampler implements Sampler {
+  shouldSample(
+    _context: Context,
+    _traceId: string,
+    _spanName: string,
+    _spanKind: SpanKind,
+    attributes: Attributes,
+    _links: Link[],
+  ): SamplingResult {
+    let filter = false;
+    FILTERED_ATTRIBUTE_KEYS.forEach((attribute) => {
+      if (attributes?.[attribute]) {
+        filter = true;
+      }
+    });
+
+    return {
+      decision: filter
+        ? SamplingDecision.NOT_RECORD
+        : SamplingDecision.RECORD_AND_SAMPLED,
+    };
+  }
+
+  toString(): string {
+    return "TraceloopSampler";
+  }
+}

--- a/packages/traceloop-sdk/src/lib/tracing/sampler.ts
+++ b/packages/traceloop-sdk/src/lib/tracing/sampler.ts
@@ -17,8 +17,8 @@ export class TraceloopSampler implements Sampler {
     _links: Link[],
   ): SamplingResult {
     let filter = false;
-    FILTERED_ATTRIBUTE_KEYS.forEach((attribute) => {
-      if (attributes?.[attribute]) {
+    FILTERED_ATTRIBUTE_KEYS.forEach((key) => {
+      if (attributes?.[key]) {
         filter = true;
       }
     });


### PR DESCRIPTION
Filters NextJS spans that have a `next.span_name` but leaves all others

<img width="541" alt="image" src="https://github.com/traceloop/openllmetry-js/assets/42910634/7f1a81a5-9451-4e89-bfea-3fff04eea2c0">
