### PR TITLE
fix: do not patch modules

### DIFF
--- a/packages/instrumentation-azure/src/instrumentation.ts
+++ b/packages/instrumentation-azure/src/instrumentation.ts
@@ -50,13 +50,7 @@ export class AzureOpenAIInstrumentation extends InstrumentationBase<any> {
     super.setConfig(config);
   }
 
-  public manuallyInstrument(
-    module: typeof azure & { openLLMetryPatched?: boolean },
-  ) {
-    if (module.openLLMetryPatched) {
-      return;
-    }
-
+  public manuallyInstrument(module: typeof azure) {
     this._wrap(
       module.OpenAIClient.prototype,
       "getChatCompletions",
@@ -80,15 +74,7 @@ export class AzureOpenAIInstrumentation extends InstrumentationBase<any> {
     return module;
   }
 
-  private patch(
-    moduleExports: typeof azure & { openLLMetryPatched?: boolean },
-  ) {
-    if (moduleExports.openLLMetryPatched) {
-      return moduleExports;
-    }
-
-    moduleExports.openLLMetryPatched = true;
-
+  private patch(moduleExports: typeof azure) {
     this._wrap(
       moduleExports.OpenAIClient.prototype,
       "getChatCompletions",
@@ -102,11 +88,7 @@ export class AzureOpenAIInstrumentation extends InstrumentationBase<any> {
     return moduleExports;
   }
 
-  private unpatch(
-    moduleExports: typeof azure & { openLLMetryPatched?: boolean },
-  ): void {
-    moduleExports.openLLMetryPatched = false;
-
+  private unpatch(moduleExports: typeof azure): void {
     this._unwrap(moduleExports.OpenAIClient.prototype, "getChatCompletions");
     this._unwrap(moduleExports.OpenAIClient.prototype, "getCompletions");
   }

--- a/packages/instrumentation-bedrock/src/instrumentation.ts
+++ b/packages/instrumentation-bedrock/src/instrumentation.ts
@@ -57,15 +57,7 @@ export class BedrockInstrumentation extends InstrumentationBase<any> {
     return module;
   }
 
-  public manuallyInstrument(
-    module: typeof bedrock & { openLLMetryPatched?: boolean },
-  ) {
-    if (module.openLLMetryPatched) {
-      return;
-    }
-
-    module.openLLMetryPatched = true;
-
+  public manuallyInstrument(module: typeof bedrock) {
     this._wrap(
       module.BedrockRuntimeClient.prototype,
       "send",
@@ -73,13 +65,7 @@ export class BedrockInstrumentation extends InstrumentationBase<any> {
     );
   }
 
-  private wrap(module: typeof bedrock & { openLLMetryPatched?: boolean }) {
-    if (module.openLLMetryPatched) {
-      return module;
-    }
-
-    module.openLLMetryPatched = true;
-
+  private wrap(module: typeof bedrock) {
     this._wrap(
       module.BedrockRuntimeClient.prototype,
       "send",
@@ -89,9 +75,7 @@ export class BedrockInstrumentation extends InstrumentationBase<any> {
     return module;
   }
 
-  private unwrap(module: typeof bedrock & { openLLMetryPatched?: boolean }) {
-    module.openLLMetryPatched = false;
-
+  private unwrap(module: typeof bedrock) {
     this._unwrap(module.BedrockRuntimeClient.prototype, "send");
   }
 

--- a/packages/instrumentation-cohere/src/instrumentation.ts
+++ b/packages/instrumentation-cohere/src/instrumentation.ts
@@ -59,19 +59,11 @@ export class CohereInstrumentation extends InstrumentationBase<any> {
     return module;
   }
 
-  public manuallyInstrument(
-    module: typeof cohere & { openLLMetryPatched?: boolean },
-  ) {
+  public manuallyInstrument(module: typeof cohere) {
     this.wrap(module);
   }
 
-  private wrap(module: typeof cohere & { openLLMetryPatched?: boolean }) {
-    if (module.openLLMetryPatched) {
-      return module;
-    }
-
-    module.openLLMetryPatched = true;
-
+  private wrap(module: typeof cohere) {
     this._wrap(
       module.CohereClient.prototype,
       "generate",
@@ -101,9 +93,7 @@ export class CohereInstrumentation extends InstrumentationBase<any> {
     return module;
   }
 
-  private unwrap(module: typeof cohere & { openLLMetryPatched?: boolean }) {
-    module.openLLMetryPatched = false;
-
+  private unwrap(module: typeof cohere) {
     this._unwrap(module.CohereClient.prototype, "generateStream");
     this._unwrap(module.CohereClient.prototype, "chat");
     this._unwrap(module.CohereClient.prototype, "chatStream");

--- a/packages/instrumentation-langchain/src/instrumentation.ts
+++ b/packages/instrumentation-langchain/src/instrumentation.ts
@@ -37,9 +37,9 @@ export class LangChainInstrumentation extends InstrumentationBase<any> {
     agentsModule,
     toolsModule,
   }: {
-    chainsModule?: any & { openLLMetryPatched?: boolean };
-    agentsModule?: any & { openLLMetryPatched?: boolean };
-    toolsModule?: any & { openLLMetryPatched?: boolean };
+    chainsModule?: any;
+    agentsModule?: any;
+    toolsModule?: any;
   }) {
     if (chainsModule) {
       this.patchChainModule(chainsModule);
@@ -74,13 +74,7 @@ export class LangChainInstrumentation extends InstrumentationBase<any> {
     return [chainModule, agentModule, toolsModule];
   }
 
-  private patchChainModule(
-    moduleExports: typeof ChainsModule & { openLLMetryPatched?: boolean },
-  ) {
-    if (moduleExports.openLLMetryPatched) {
-      return moduleExports;
-    }
-
+  private patchChainModule(moduleExports: typeof ChainsModule) {
     this._wrap(
       moduleExports.RetrievalQAChain.prototype,
       "_call",
@@ -98,13 +92,7 @@ export class LangChainInstrumentation extends InstrumentationBase<any> {
     return moduleExports;
   }
 
-  private patchAgentModule(
-    moduleExports: typeof AgentsModule & { openLLMetryPatched?: boolean },
-  ) {
-    if (moduleExports.openLLMetryPatched) {
-      return moduleExports;
-    }
-
+  private patchAgentModule(moduleExports: typeof AgentsModule) {
     this._wrap(
       moduleExports.AgentExecutor.prototype,
       "_call",
@@ -117,13 +105,7 @@ export class LangChainInstrumentation extends InstrumentationBase<any> {
     return moduleExports;
   }
 
-  private patchToolsModule(
-    moduleExports: typeof ToolsModule & { openLLMetryPatched?: boolean },
-  ) {
-    if (moduleExports.openLLMetryPatched) {
-      return moduleExports;
-    }
-
+  private patchToolsModule(moduleExports: typeof ToolsModule) {
     this._wrap(
       moduleExports.Tool.prototype,
       "call",
@@ -132,30 +114,18 @@ export class LangChainInstrumentation extends InstrumentationBase<any> {
     return moduleExports;
   }
 
-  private unpatchChainModule(
-    moduleExports: any & { openLLMetryPatched?: boolean },
-  ) {
-    moduleExports.openLLMetryPatched = false;
-
+  private unpatchChainModule(moduleExports: any) {
     this._unwrap(moduleExports.RetrievalQAChain.prototype, "_call");
     this._unwrap(moduleExports.BaseChain.prototype, "call");
     return moduleExports;
   }
 
-  private unpatchAgentModule(
-    moduleExports: any & { openLLMetryPatched?: boolean },
-  ) {
-    moduleExports.openLLMetryPatched = false;
-
+  private unpatchAgentModule(moduleExports: any) {
     this._unwrap(moduleExports.AgentExecutor.prototype, "_call");
     return moduleExports;
   }
 
-  private unpatchToolsModule(
-    moduleExports: any & { openLLMetryPatched?: boolean },
-  ) {
-    moduleExports.openLLMetryPatched = false;
-
+  private unpatchToolsModule(moduleExports: any) {
     this._unwrap(moduleExports.AgentExecutor.prototype, "_call");
     return moduleExports;
   }

--- a/packages/instrumentation-llamaindex/src/instrumentation.ts
+++ b/packages/instrumentation-llamaindex/src/instrumentation.ts
@@ -39,9 +39,7 @@ export class LlamaIndexInstrumentation extends InstrumentationBase<any> {
     super.setConfig(config);
   }
 
-  public manuallyInstrument(
-    module: typeof llamaindex & { openLLMetryPatched?: boolean },
-  ) {
+  public manuallyInstrument(module: typeof llamaindex) {
     this.patch(module);
   }
 
@@ -80,15 +78,7 @@ export class LlamaIndexInstrumentation extends InstrumentationBase<any> {
     return retriever && (retriever as BaseRetriever).retrieve !== undefined;
   }
 
-  private patch(
-    moduleExports: typeof llamaindex & { openLLMetryPatched?: boolean },
-  ) {
-    if (moduleExports.openLLMetryPatched) {
-      return moduleExports;
-    }
-
-    moduleExports.openLLMetryPatched = true;
-
+  private patch(moduleExports: typeof llamaindex) {
     const customLLMInstrumentation = new CustomLLMInstrumentation(
       this._config,
       () => this.tracer, // this is on purpose. Tracer may change
@@ -168,11 +158,7 @@ export class LlamaIndexInstrumentation extends InstrumentationBase<any> {
     return moduleExports;
   }
 
-  private unpatch(
-    moduleExports: typeof llamaindex & { openLLMetryPatched?: boolean },
-  ) {
-    moduleExports.openLLMetryPatched = false;
-
+  private unpatch(moduleExports: typeof llamaindex) {
     this._unwrap(moduleExports.RetrieverQueryEngine.prototype, "query");
 
     for (const key in moduleExports) {

--- a/packages/instrumentation-openai/src/instrumentation.ts
+++ b/packages/instrumentation-openai/src/instrumentation.ts
@@ -55,13 +55,7 @@ export class OpenAIInstrumentation extends InstrumentationBase<any> {
     super.setConfig(config);
   }
 
-  public manuallyInstrument(
-    module: typeof openai.OpenAI & { openLLMetryPatched?: boolean },
-  ) {
-    if (module.openLLMetryPatched) {
-      return;
-    }
-
+  public manuallyInstrument(module: typeof openai.OpenAI) {
     // Old version of OpenAI API (v3.1.0)
     if ((module as any).OpenAIApi) {
       this._wrap(
@@ -98,15 +92,7 @@ export class OpenAIInstrumentation extends InstrumentationBase<any> {
     return module;
   }
 
-  private patch(
-    moduleExports: typeof openai & { openLLMetryPatched?: boolean },
-  ) {
-    if (moduleExports.openLLMetryPatched) {
-      return moduleExports;
-    }
-
-    moduleExports.openLLMetryPatched = true;
-
+  private patch(moduleExports: typeof openai) {
     // Old version of OpenAI API (v3.1.0)
     if ((moduleExports as any).OpenAIApi) {
       this._wrap(
@@ -134,11 +120,7 @@ export class OpenAIInstrumentation extends InstrumentationBase<any> {
     return moduleExports;
   }
 
-  private unpatch(
-    moduleExports: typeof openai & { openLLMetryPatched?: boolean },
-  ): void {
-    moduleExports.openLLMetryPatched = false;
-
+  private unpatch(moduleExports: typeof openai): void {
     // Old version of OpenAI API (v3.1.0)
     if ((moduleExports as any).OpenAIApi) {
       this._unwrap(

--- a/packages/instrumentation-pinecone/src/instrumentation.ts
+++ b/packages/instrumentation-pinecone/src/instrumentation.ts
@@ -33,9 +33,7 @@ export class PineconeInstrumentation extends InstrumentationBase<any> {
     super("@traceloop/instrumentation-pinecone", "0.3.0", config);
   }
 
-  public manuallyInstrument(
-    module: typeof pinecone & { openLLMetryPatched?: boolean },
-  ) {
+  public manuallyInstrument(module: typeof pinecone) {
     this.patch(module);
   }
 
@@ -49,15 +47,7 @@ export class PineconeInstrumentation extends InstrumentationBase<any> {
     return module;
   }
 
-  private patch(
-    moduleExports: typeof pinecone & { openLLMetryPatched?: boolean },
-  ) {
-    if (moduleExports.openLLMetryPatched) {
-      return moduleExports;
-    }
-
-    moduleExports.openLLMetryPatched = true;
-
+  private patch(moduleExports: typeof pinecone) {
     this._wrap(
       moduleExports.Index.prototype,
       "query",
@@ -87,11 +77,7 @@ export class PineconeInstrumentation extends InstrumentationBase<any> {
     return moduleExports;
   }
 
-  private unpatch(
-    moduleExports: typeof pinecone & { openLLMetryPatched?: boolean },
-  ): void {
-    moduleExports.openLLMetryPatched = false;
-
+  private unpatch(moduleExports: typeof pinecone): void {
     this._unwrap(moduleExports.Index.prototype, "query");
     this._unwrap(moduleExports.Index.prototype, "upsert");
     this._unwrap(moduleExports.Index.prototype, "deleteAll");

--- a/packages/instrumentation-vertexai/src/aiplatform-instrumentation.ts
+++ b/packages/instrumentation-vertexai/src/aiplatform-instrumentation.ts
@@ -57,15 +57,7 @@ export class AIPlatformInstrumentation extends InstrumentationBase<any> {
     return aiPlatformModule;
   }
 
-  public manuallyInstrument(
-    module: typeof aiplatform & { openLLMetryPatched?: boolean },
-  ) {
-    if (module.openLLMetryPatched) {
-      return;
-    }
-
-    module.openLLMetryPatched = true;
-
+  public manuallyInstrument(module: typeof aiplatform) {
     this._wrap(
       module.PredictionServiceClient.prototype,
       "predict",
@@ -73,13 +65,7 @@ export class AIPlatformInstrumentation extends InstrumentationBase<any> {
     );
   }
 
-  private wrap(module: typeof aiplatform & { openLLMetryPatched?: boolean }) {
-    if (module.openLLMetryPatched) {
-      return module;
-    }
-
-    module.openLLMetryPatched = true;
-
+  private wrap(module: typeof aiplatform) {
     this._wrap(
       module.PredictionServiceClient.prototype,
       "predict",
@@ -89,11 +75,7 @@ export class AIPlatformInstrumentation extends InstrumentationBase<any> {
     return module;
   }
 
-  private unwrap(
-    module: typeof aiplatform & { openLLMetryPatched?: boolean },
-  ): void {
-    module.openLLMetryPatched = false;
-
+  private unwrap(module: typeof aiplatform): void {
     this._unwrap(module.PredictionServiceClient.prototype, "predict");
   }
 

--- a/packages/instrumentation-vertexai/src/vertexai-instrumentation.ts
+++ b/packages/instrumentation-vertexai/src/vertexai-instrumentation.ts
@@ -62,15 +62,7 @@ export class VertexAIInstrumentation extends InstrumentationBase<any> {
     this.modelConfig = { ...newValue };
   }
 
-  public manuallyInstrument(
-    module: typeof vertexAI & { openLLMetryPatched?: boolean },
-  ) {
-    if (module.openLLMetryPatched) {
-      return;
-    }
-
-    module.openLLMetryPatched = true;
-
+  public manuallyInstrument(module: typeof vertexAI) {
     this._wrap(
       module.VertexAI_Preview.prototype,
       "getGenerativeModel",
@@ -83,13 +75,7 @@ export class VertexAIInstrumentation extends InstrumentationBase<any> {
     );
   }
 
-  private wrap(module: typeof vertexAI & { openLLMetryPatched?: boolean }) {
-    if (module.openLLMetryPatched) {
-      return module;
-    }
-
-    module.openLLMetryPatched = true;
-
+  private wrap(module: typeof vertexAI) {
     this._wrap(
       module.VertexAI_Preview.prototype,
       "getGenerativeModel",
@@ -104,11 +90,7 @@ export class VertexAIInstrumentation extends InstrumentationBase<any> {
     return module;
   }
 
-  private unwrap(
-    module: typeof vertexAI & { openLLMetryPatched?: boolean },
-  ): void {
-    module.openLLMetryPatched = false;
-
+  private unwrap(module: typeof vertexAI): void {
     this._unwrap(module.VertexAI_Preview.prototype, "getGenerativeModel");
     this._unwrap(module.GenerativeModel.prototype, "generateContentStream");
   }


### PR DESCRIPTION
This causes exceptions in some environments. We need to figure out another way to make sure we don't double-patch.