### PR TITLE
fix: include dist .mjs for packages with modules declared

### DIFF
--- a/packages/instrumentation-anthropic/package.json
+++ b/packages/instrumentation-anthropic/package.json
@@ -26,6 +26,7 @@
   },
   "files": [
     "dist/**/*.js",
+    "dist/**/*.mjs",
     "dist/**/*.js.map",
     "dist/**/*.d.ts",
     "doc",

--- a/packages/instrumentation-azure/package.json
+++ b/packages/instrumentation-azure/package.json
@@ -26,6 +26,7 @@
   },
   "files": [
     "dist/**/*.js",
+    "dist/**/*.mjs",
     "dist/**/*.js.map",
     "dist/**/*.d.ts",
     "doc",

--- a/packages/instrumentation-bedrock/package.json
+++ b/packages/instrumentation-bedrock/package.json
@@ -26,6 +26,7 @@
   },
   "files": [
     "dist/**/*.js",
+    "dist/**/*.mjs",
     "dist/**/*.js.map",
     "dist/**/*.d.ts",
     "doc",

--- a/packages/instrumentation-cohere/package.json
+++ b/packages/instrumentation-cohere/package.json
@@ -26,6 +26,7 @@
   },
   "files": [
     "dist/**/*.js",
+    "dist/**/*.mjs",
     "dist/**/*.js.map",
     "dist/**/*.d.ts",
     "doc",

--- a/packages/instrumentation-langchain/package.json
+++ b/packages/instrumentation-langchain/package.json
@@ -26,6 +26,7 @@
   },
   "files": [
     "dist/**/*.js",
+    "dist/**/*.mjs",
     "dist/**/*.js.map",
     "dist/**/*.d.ts",
     "doc",

--- a/packages/instrumentation-llamaindex/package.json
+++ b/packages/instrumentation-llamaindex/package.json
@@ -25,6 +25,7 @@
   },
   "files": [
     "dist/**/*.js",
+    "dist/**/*.mjs",
     "dist/**/*.js.map",
     "dist/**/*.d.ts",
     "doc",

--- a/packages/instrumentation-openai/package.json
+++ b/packages/instrumentation-openai/package.json
@@ -25,6 +25,7 @@
   },
   "files": [
     "dist/**/*.js",
+    "dist/**/*.mjs",
     "dist/**/*.js.map",
     "dist/**/*.d.ts",
     "doc",

--- a/packages/instrumentation-pinecone/package.json
+++ b/packages/instrumentation-pinecone/package.json
@@ -26,6 +26,7 @@
   },
   "files": [
     "dist/**/*.js",
+    "dist/**/*.mjs",
     "dist/**/*.js.map",
     "dist/**/*.d.ts",
     "doc",

--- a/packages/instrumentation-vertexai/package.json
+++ b/packages/instrumentation-vertexai/package.json
@@ -25,6 +25,7 @@
   },
   "files": [
     "dist/**/*.js",
+    "dist/**/*.mjs",
     "dist/**/*.js.map",
     "dist/**/*.d.ts",
     "doc",


### PR DESCRIPTION
I also noticed that a couple packages have esm modules built but neither have them declared in `package.json` _nor_ included as `files`, but I wasn't sure if that was intentional. That would more likely be a feature than a fix anyway.

If desired, I can add a commit to declare and include those packages too.