### PR TITLE
feat(instrumentation-chromadb,instrumentation-qdrant): add esm exports

### DIFF
--- a/packages/instrumentation-chromadb/package.json
+++ b/packages/instrumentation-chromadb/package.json
@@ -3,6 +3,7 @@
   "version": "0.10.0",
   "description": "ChromaDB Instrumentation",
   "main": "dist/src/index.js",
+  "module": "dist/src/index.mjs",
   "types": "dist/src/index.d.ts",
   "repository": "traceloop/openllmetry-js",
   "scripts": {
@@ -25,6 +26,7 @@
   },
   "files": [
     "dist/src/**/*.js",
+    "dist/src/**/*.mjs",
     "dist/src/**/*.js.map",
     "dist/src/**/*.d.ts",
     "doc",

--- a/packages/instrumentation-qdrant/package.json
+++ b/packages/instrumentation-qdrant/package.json
@@ -3,6 +3,7 @@
   "version": "0.10.0",
   "description": "Qdrant Instrumentation",
   "main": "dist/src/index.js",
+  "module": "dist/src/index.mjs",
   "types": "dist/src/index.d.ts",
   "repository": "traceloop/openllmetry-js",
   "scripts": {
@@ -25,6 +26,7 @@
   },
   "files": [
     "dist/src/**/*.js",
+    "dist/src/**/*.mjs",
     "dist/src/**/*.js.map",
     "dist/src/**/*.d.ts",
     "doc",


### PR DESCRIPTION
As discussed in #425, adding ESM exports for packages which didn't
previously have them.
