### PR TITLE
fix(langchain): return exports in langchain runnables module patch

### DIFF
--- a/packages/instrumentation-langchain/src/instrumentation.ts
+++ b/packages/instrumentation-langchain/src/instrumentation.ts
@@ -190,6 +190,7 @@ export class LangChainInstrumentation extends InstrumentationBase {
       "invoke",
       taskWrapper(() => this.tracer, this._shouldSendPrompts()),
     );
+    return moduleExports;
   }
 
   private unpatchChainModule(


### PR DESCRIPTION
Patch methods need to return `moduleExports` like the other ones, just this one seems to have missed it as a typo