### PR TITLE
fix(traceloop-sdk): omit spans of non-traceloop instrumentations by default when using standalone processor

### DIFF
--- a/packages/sample-app/src/sample_otel_sdk.ts
+++ b/packages/sample-app/src/sample_otel_sdk.ts
@@ -1,6 +1,6 @@
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import { Resource } from "@opentelemetry/resources";
-import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
+import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 import {
   createSpanProcessor,
   withTask,
@@ -13,12 +13,13 @@ const traceloopSpanProcessor = createSpanProcessor({
   apiKey: process.env.TRACELOOP_API_KEY,
   baseUrl: process.env.TRACELOOP_BASE_URL,
   disableBatch: true,
+  allowedInstrumentationLibraries: ["my-sample-app"],
 });
 
 // Initialize the OpenTelemetry SDK with Traceloop's span processor
 const sdk = new NodeSDK({
   resource: new Resource({
-    [SemanticResourceAttributes.SERVICE_NAME]: "my-sample-app",
+    [ATTR_SERVICE_NAME]: "my-sample-app",
   }),
   spanProcessors: [traceloopSpanProcessor],
 });

--- a/packages/traceloop-sdk/src/lib/tracing/index.ts
+++ b/packages/traceloop-sdk/src/lib/tracing/index.ts
@@ -4,7 +4,7 @@ import { baggageUtils } from "@opentelemetry/core";
 import { context, diag } from "@opentelemetry/api";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
 import { Resource } from "@opentelemetry/resources";
-import { SEMRESATTRS_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
+import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 import { Instrumentation } from "@opentelemetry/instrumentation";
 import { InitializeOptions } from "../interfaces";
 import { Telemetry } from "../telemetry/telemetry";
@@ -25,7 +25,10 @@ import { LangChainInstrumentation } from "@traceloop/instrumentation-langchain";
 import { ChromaDBInstrumentation } from "@traceloop/instrumentation-chromadb";
 import { QdrantInstrumentation } from "@traceloop/instrumentation-qdrant";
 import { TogetherInstrumentation } from "@traceloop/instrumentation-together";
-import { createSpanProcessor } from "./span-processor";
+import {
+  ALL_INSTRUMENTATION_LIBRARIES,
+  createSpanProcessor,
+} from "./span-processor";
 
 let _sdk: NodeSDK;
 let _spanProcessor: SpanProcessor;
@@ -268,6 +271,7 @@ export const startTracing = (options: InitializeOptions) => {
     disableBatch: options.disableBatch,
     exporter: traceExporter,
     headers,
+    allowedInstrumentationLibraries: ALL_INSTRUMENTATION_LIBRARIES,
   });
 
   const spanProcessors: SpanProcessor[] = [_spanProcessor];
@@ -277,8 +281,7 @@ export const startTracing = (options: InitializeOptions) => {
 
   _sdk = new NodeSDK({
     resource: new Resource({
-      [SEMRESATTRS_SERVICE_NAME]:
-        options.appName || process.env.npm_package_name,
+      [ATTR_SERVICE_NAME]: options.appName || process.env.npm_package_name,
     }),
     spanProcessors,
     contextManager: options.contextManager,

--- a/packages/traceloop-sdk/src/lib/tracing/span-processor.ts
+++ b/packages/traceloop-sdk/src/lib/tracing/span-processor.ts
@@ -95,7 +95,7 @@ export const createSpanProcessor = (
   ) {
     spanProcessor.onEnd = onSpanEnd(originalOnEnd);
   } else {
-    const instrumentationLibraries = traceloopInstrumentationLibraries;
+    const instrumentationLibraries = [...traceloopInstrumentationLibraries];
 
     if (options.allowedInstrumentationLibraries) {
       instrumentationLibraries.push(...options.allowedInstrumentationLibraries);

--- a/packages/traceloop-sdk/src/lib/tracing/span-processor.ts
+++ b/packages/traceloop-sdk/src/lib/tracing/span-processor.ts
@@ -163,17 +163,11 @@ const onSpanEnd = (
   originalOnEnd: (span: ReadableSpan) => void,
   instrumentationLibraries?: string[],
 ) => {
-  console.log("instrumentation libraries", instrumentationLibraries);
   return (span: ReadableSpan): void => {
-    console.log(
-      "instrumentation library name",
-      span.instrumentationLibrary.name,
-    );
     if (
       instrumentationLibraries &&
       !instrumentationLibraries.includes(span.instrumentationLibrary.name)
     ) {
-      console.log("skipping span", span.instrumentationLibrary.name);
       return;
     }
 

--- a/packages/traceloop-sdk/src/lib/tracing/tracing.ts
+++ b/packages/traceloop-sdk/src/lib/tracing/tracing.ts
@@ -1,7 +1,7 @@
 import { trace, createContextKey } from "@opentelemetry/api";
 import { Context } from "@opentelemetry/api/build/src/context/types";
 
-const TRACER_NAME = "traceloop.tracer";
+const TRACER_NAME = "@traceloop/node-server-sdk";
 export const WORKFLOW_NAME_KEY = createContextKey("workflow_name");
 export const ENTITY_NAME_KEY = createContextKey("entity_name");
 export const ASSOCATION_PROPERTIES_KEY = createContextKey(


### PR DESCRIPTION
- [ ] Add tests (will do it in a different PR, i'm having hard times testing it and want to release this one for a customer)