### PR TITLE
fix(tracing): introduce tracingEnabled option to support sdk initialization for standalone processor

### DIFF
--- a/packages/sample-app/src/sample_otel_sdk.ts
+++ b/packages/sample-app/src/sample_otel_sdk.ts
@@ -1,15 +1,16 @@
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import { Resource } from "@opentelemetry/resources";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
-import {
-  createSpanProcessor,
-  withTask,
-  withWorkflow,
-} from "@traceloop/node-server-sdk";
+import * as traceloop from "@traceloop/node-server-sdk";
 import { trace } from "@opentelemetry/api";
 import OpenAI from "openai";
 
-const traceloopSpanProcessor = createSpanProcessor({
+traceloop.initialize({
+  tracingEnabled: false,
+  traceloopSyncEnabled: false,
+});
+
+const traceloopSpanProcessor = traceloop.createSpanProcessor({
   apiKey: process.env.TRACELOOP_API_KEY,
   baseUrl: process.env.TRACELOOP_BASE_URL,
   disableBatch: true,
@@ -45,9 +46,9 @@ async function main() {
 }
 
 async function chat() {
-  return await withWorkflow({ name: "sample_chat" }, async () => {
-    return await withTask({ name: "parent_task" }, async () => {
-      return await withTask({ name: "child_task" }, async () => {
+  return await traceloop.withWorkflow({ name: "sample_chat" }, async () => {
+    return await traceloop.withTask({ name: "parent_task" }, async () => {
+      return await traceloop.withTask({ name: "child_task" }, async () => {
         const chatCompletion = await openai.chat.completions.create({
           messages: [
             { role: "user", content: "Tell me a joke about OpenTelemetry" },

--- a/packages/traceloop-sdk/src/lib/configuration/index.ts
+++ b/packages/traceloop-sdk/src/lib/configuration/index.ts
@@ -86,7 +86,10 @@ export const initialize = (options: InitializeOptions) => {
     );
   }
 
-  startTracing(_configuration);
+  if (options.tracingEnabled === undefined || options.tracingEnabled) {
+    startTracing(_configuration);
+  }
+
   initializeRegistry(_configuration);
   if (options.apiKey) {
     _client = new TraceloopClient({

--- a/packages/traceloop-sdk/src/lib/interfaces/initialize-options.interface.ts
+++ b/packages/traceloop-sdk/src/lib/interfaces/initialize-options.interface.ts
@@ -142,4 +142,10 @@ export interface InitializeOptions {
    * Defaults to false.
    */
   silenceInitializationMessage?: boolean;
+
+  /**
+   * Whether to enable tracing. Optional.
+   * Defaults to true.
+   */
+  tracingEnabled?: boolean;
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `tracingEnabled` option to Traceloop SDK to control tracing initialization, updating sample app and interfaces accordingly.
> 
>   - **Behavior**:
>     - Introduces `tracingEnabled` option in `InitializeOptions` to control tracing initialization.
>     - In `index.ts`, `initialize()` now checks `tracingEnabled` before calling `startTracing()`.
>   - **Sample App**:
>     - Updates `sample_otel_sdk.ts` to use `tracingEnabled: false` in `traceloop.initialize()`.
>     - Replaces direct imports with `traceloop` namespace for `createSpanProcessor`, `withTask`, and `withWorkflow`.
>   - **Interfaces**:
>     - Adds `tracingEnabled` to `InitializeOptions` in `initialize-options.interface.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry-js&utm_source=github&utm_medium=referral)<sup> for 9a9db7f133a3f8c5f7147a7e37aaa8b1053c6c1b. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->