### PR TITLE
fix(tracing): otel log level setup only for non-standalone processor

### DIFF
--- a/packages/traceloop-sdk/src/lib/configuration/index.ts
+++ b/packages/traceloop-sdk/src/lib/configuration/index.ts
@@ -71,13 +71,6 @@ export const initialize = (options: InitializeOptions) => {
 
   _configuration = Object.freeze(options);
 
-  if (options.logLevel) {
-    diag.setLogger(
-      new DiagConsoleLogger(),
-      logLevelToOtelLogLevel(options.logLevel),
-    );
-  }
-
   if (!options.silenceInitializationMessage) {
     console.log(
       `Traceloop exporting traces to ${
@@ -87,6 +80,13 @@ export const initialize = (options: InitializeOptions) => {
   }
 
   if (options.tracingEnabled === undefined || options.tracingEnabled) {
+    if (options.logLevel) {
+      diag.setLogger(
+        new DiagConsoleLogger(),
+        logLevelToOtelLogLevel(options.logLevel),
+      );
+    }
+
     startTracing(_configuration);
   }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Moves OpenTelemetry log level setup in `initialize()` to occur only when tracing is enabled, preventing setup for standalone processors.
> 
>   - **Behavior**:
>     - Moves OpenTelemetry log level setup inside the `if` block checking `options.tracingEnabled` in `initialize()` in `index.ts`.
>     - Ensures log level setup only occurs when tracing is enabled, preventing setup for standalone processors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry-js&utm_source=github&utm_medium=referral)<sup> for 28e416516c787fe8020bcfe5a9fbbf21527b95a3. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->