### PR TITLE
fix(anthropic): upgrade supported version of anthropic SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13672,14 +13672,14 @@
       }
     },
     "node_modules/@pollyjs/adapter-fetch": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@pollyjs/adapter-fetch/-/adapter-fetch-6.0.6.tgz",
-      "integrity": "sha512-euWzM5TnA2jptdJgjIkEd/Q2hNFB652XivPKerWpLMFB13IKlrERX9wn2Dw3pquDAP0LvXH1qVBZt5DK0Xhzyg==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@pollyjs/adapter-fetch/-/adapter-fetch-6.0.7.tgz",
+      "integrity": "sha512-kv44DROx/2qzlcgS71EccGr2/I5nK40Xt92paGNI+1/Kmz290bw/ykt8cvXDg4O4xCc9Fh/jXeAkS7qwGpCx2g==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@pollyjs/adapter": "^6.0.6",
         "@pollyjs/utils": "^6.0.6",
-        "detect-node": "^2.1.0",
         "to-arraybuffer": "^1.0.1"
       }
     },
@@ -18943,13 +18943,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/detect-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/detect-port": {
       "version": "1.6.1",
@@ -30912,7 +30905,8 @@
         "tslib": "^2.8.1"
       },
       "devDependencies": {
-        "@anthropic-ai/sdk": "^0.32.1",
+        "@anthropic-ai/sdk": "^0.50.4",
+        "@pollyjs/adapter-fetch": "^6.0.7",
         "@pollyjs/adapter-node-http": "^6.0.6",
         "@pollyjs/core": "^6.0.6",
         "@pollyjs/persister-fs": "^6.0.6",
@@ -30921,6 +30915,19 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "packages/instrumentation-anthropic/node_modules/@anthropic-ai/sdk": {
+      "version": "0.50.4",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.50.4.tgz",
+      "integrity": "sha512-zZOWyIuznx2uqiRcCNuidkAsLC8IBHgS9lTwSVEB29sUCwEcqL95MWpWP1nccHSKfiZga+hbZaI0btR2zjuMmw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "packages/instrumentation-azure": {
@@ -32833,7 +32840,7 @@
       },
       "devDependencies": {
         "@ai-sdk/openai": "^1.0.10",
-        "@anthropic-ai/sdk": "^0.32.1",
+        "@anthropic-ai/sdk": "^0.50.4",
         "@aws-sdk/client-bedrock-runtime": "^3.709.0",
         "@azure/openai": "^1.0.0-beta.13",
         "@google-cloud/aiplatform": "^3.34.0",
@@ -32857,6 +32864,19 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "packages/traceloop-sdk/node_modules/@anthropic-ai/sdk": {
+      "version": "0.50.4",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.50.4.tgz",
+      "integrity": "sha512-zZOWyIuznx2uqiRcCNuidkAsLC8IBHgS9lTwSVEB29sUCwEcqL95MWpWP1nccHSKfiZga+hbZaI0btR2zjuMmw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "packages/traceloop-sdk/node_modules/@types/node": {

--- a/packages/instrumentation-anthropic/package.json
+++ b/packages/instrumentation-anthropic/package.json
@@ -45,8 +45,9 @@
     "tslib": "^2.8.1"
   },
   "devDependencies": {
-    "@anthropic-ai/sdk": "^0.32.1",
+    "@anthropic-ai/sdk": "^0.50.4",
     "@pollyjs/adapter-node-http": "^6.0.6",
+    "@pollyjs/adapter-fetch": "^6.0.7",
     "@pollyjs/core": "^6.0.6",
     "@pollyjs/persister-fs": "^6.0.6",
     "@types/mocha": "^10.0.10",

--- a/packages/instrumentation-anthropic/recordings/Test-Anthropic-instrumentation_3769946143/should-set-attributes-in-span-for-completions-streaming_2198009633/recording.har
+++ b/packages/instrumentation-anthropic/recordings/Test-Anthropic-instrumentation_3769946143/should-set-attributes-in-span-for-completions-streaming_2198009633/recording.har
@@ -8,147 +8,143 @@
     },
     "entries": [
       {
-        "_id": "411df901c53641005b599f973e8b2068",
+        "_id": "3345e7bba2eeb5b2413ea7cdcbc2110d",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 149,
+          "bodySize": 132,
           "cookies": [],
           "headers": [
             {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "149"
-            },
-            {
-              "_fromType": "array",
               "name": "accept",
               "value": "application/json"
             },
             {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "Anthropic/JS 0.20.1"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-stainless-lang",
-              "value": "js"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-stainless-package-version",
-              "value": "0.20.1"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-stainless-os",
-              "value": "MacOS"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-stainless-arch",
-              "value": "arm64"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-stainless-runtime",
-              "value": "node"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-stainless-runtime-version",
-              "value": "v18.17.1"
-            },
-            {
-              "_fromType": "array",
               "name": "anthropic-version",
               "value": "2023-06-01"
             },
             {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
+              "name": "content-type",
+              "value": "application/json"
             },
             {
-              "name": "host",
-              "value": "api.anthropic.com"
+              "name": "user-agent",
+              "value": "Anthropic/JS 0.50.4"
+            },
+            {
+              "name": "x-stainless-arch",
+              "value": "arm64"
+            },
+            {
+              "name": "x-stainless-lang",
+              "value": "js"
+            },
+            {
+              "name": "x-stainless-os",
+              "value": "MacOS"
+            },
+            {
+              "name": "x-stainless-package-version",
+              "value": "0.50.4"
+            },
+            {
+              "name": "x-stainless-retry-count",
+              "value": "0"
+            },
+            {
+              "name": "x-stainless-runtime",
+              "value": "node"
+            },
+            {
+              "name": "x-stainless-runtime-version",
+              "value": "v22.10.0"
+            },
+            {
+              "name": "x-stainless-timeout",
+              "value": "600"
             }
           ],
-          "headersSize": 548,
+          "headersSize": 525,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\n  \"model\": \"claude-2\",\n  \"max_tokens_to_sample\": 300,\n  \"prompt\": \"\\n\\nHuman: Tell me a joke about OpenTelemetry\\n\\nAssistant:\",\n  \"stream\": true\n}"
+            "text": "{\"model\":\"claude-2\",\"max_tokens_to_sample\":300,\"prompt\":\"\\n\\nHuman: Tell me a joke about OpenTelemetry\\n\\nAssistant:\",\"stream\":true}"
           },
           "queryString": [],
           "url": "https://api.anthropic.com/v1/complete"
         },
         "response": {
-          "bodySize": 6983,
+          "bodySize": 22963,
           "content": {
             "mimeType": "text/event-stream; charset=utf-8",
-            "size": 6983,
-            "text": "event: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\" Here\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\"        }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\"'s\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\"           }\r\n\r\nevent: ping\r\ndata: {\"type\": \"ping\"}\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\" a\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\"      }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\" silly\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\"        }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\" joke\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\"      }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\" about\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\"        }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\" Open\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\"            }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\"Tele\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\"               }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\"metry\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\" }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\":\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\"  }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\"\\n\\nWhat\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\"           }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\" do\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\"            }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\" you\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\"       }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\" call\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\"   }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\" an\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\"         }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\" Open\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\"            }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\"Tele\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\"        }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\"metry\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\"        }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\" collector\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\"         }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\" that\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\"     }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\" keeps\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\"               }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\" getting\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\"  }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\" distracted\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\"      }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\"?\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\" }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\" A\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\"              }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\" span\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\"   }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\"-\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\"  }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\"t\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\"           }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\"ention\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\"  }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\" deficit\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\"   }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\" tracer\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\"           }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\"!\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\"  }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\",\"completion\":\"\",\"stop_reason\":\"stop_sequence\",\"model\":\"claude-2.1\",\"stop\":\"\\n\\nHuman:\",\"log_id\":\"compl_01NxHrRrvyAuE77TjBS7tyTt\"        }\r\n\r\n"
+            "size": 22963,
+            "text": "event: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" Here\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"   }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\"'s\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"   }\r\n\r\nevent: ping\r\ndata: {\"type\": \"ping\"}\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" a\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"     }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" silly\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"             }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" attempt\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"        }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" at\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"  }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" an\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"               }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" Open\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"  }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\"Tele\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"       }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\"metry\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"             }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" joke\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"        }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\":\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"     }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\"\\n\\nWhy\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"    }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" was\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\" }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" the\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"    }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" Open\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"   }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\"Tele\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"     }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\"metry\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"    }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" trace\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"  }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" so\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"      }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" easy\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"           }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" to\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"               }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" follow\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"             }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\"?\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"  }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" Because\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"}\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" it\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"             }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" ha\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"            }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\"d great\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"    }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" instrumentation\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"          }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\"!\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"             }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\"\\n\\nI\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"          }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" trie\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"      }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\"d to\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"   }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" come\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"          }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" up\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\" }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" with\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"              }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" a\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"          }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" joke\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"    }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" playing\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"     }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" on\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"              }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" the\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"               }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" terminology\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"         }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" aroun\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"}\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\"d Open\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"      }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\"Tele\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"        }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\"metry\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"      }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\",\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"  }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" which\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"         }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" provides\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\" }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" instrumentation\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"            }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" for\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"              }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" generating\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"    }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" trace\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"         }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" data\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"    }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" an\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"     }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\"d metrics\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"           }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" from\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"              }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" applications\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"         }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\".\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"           }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" Hopefully\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"               }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" it\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"         }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" gives\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"   }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" you\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\" }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" a\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"       }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" bit\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"      }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" of\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"         }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" a\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"               }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" chuck\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"              }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\"le\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"            }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\"!\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"    }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" Let\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"         }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" me\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\" }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" know\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"        }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" if\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"        }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" you\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"   }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\"'\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"             }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\"d like\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"            }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" me\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"        }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" to\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"     }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" try\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"        }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" another\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"       }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" Open\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"               }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\"Tele\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"               }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\"metry\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"     }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\"-\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"           }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\"relate\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"            }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\"d joke\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"           }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\".\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"}\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" Coming\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"         }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" up\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"    }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" with\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"       }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" tech\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"   }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" jokes\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"          }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" on\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"   }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" the\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"         }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" spot\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"           }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" is\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"        }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" tricky\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"}\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" but\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"          }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" I\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"       }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\"'m\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"       }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" happy\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"  }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" to\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"     }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" give\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"           }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" it\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"      }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" a\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"               }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\" try\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"       }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\"!\",\"stop_reason\":null,\"model\":\"claude-2.1\",\"stop\":null,\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\"   }\r\n\r\nevent: completion\r\ndata: {\"type\":\"completion\",\"id\":\"compl_01LosELK4533mP15ac1MyvhY\",\"completion\":\"\",\"stop_reason\":\"stop_sequence\",\"model\":\"claude-2.1\",\"stop\":\"\\n\\nHuman:\",\"log_id\":\"compl_01LosELK4533mP15ac1MyvhY\" }\r\n\r\n"
           },
           "cookies": [],
           "headers": [
             {
-              "name": "date",
-              "value": "Fri, 05 Apr 2024 11:20:12 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "text/event-stream; charset=utf-8"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "keep-alive"
+              "name": "anthropic-organization-id",
+              "value": "4591fe84-abb6-4b93-9858-2c0c0b11204e"
             },
             {
               "name": "cache-control",
               "value": "no-cache"
             },
             {
-              "name": "request-id",
-              "value": "req_01QgLb4tbuUR3myMtpiyaSZX"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google"
-            },
-            {
               "name": "cf-cache-status",
               "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "94d3d25b9f6d4f4e-EWR"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-type",
+              "value": "text/event-stream; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Jun 2025 21:46:26 GMT"
+            },
+            {
+              "name": "request-id",
+              "value": "req_011CPyP3j8Dzg1E8jkVky4xJ"
             },
             {
               "name": "server",
               "value": "cloudflare"
             },
             {
-              "name": "cf-ray",
-              "value": "86f925c39fd7a268-FCO"
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
             }
           ],
-          "headersSize": 299,
+          "headersSize": 457,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-05T11:20:12.047Z",
-        "time": 2070,
+        "startedDateTime": "2025-06-09T21:46:26.408Z",
+        "time": 7894,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -156,7 +152,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 2070
+          "wait": 7894
         }
       }
     ],

--- a/packages/instrumentation-anthropic/recordings/Test-Anthropic-instrumentation_3769946143/should-set-attributes-in-span-for-completions_1224394582/recording.har
+++ b/packages/instrumentation-anthropic/recordings/Test-Anthropic-instrumentation_3769946143/should-set-attributes-in-span-for-completions_1224394582/recording.har
@@ -8,152 +8,143 @@
     },
     "entries": [
       {
-        "_id": "3d54b7ae72fa4dc3272d8f7c5bcddf6d",
+        "_id": "52fd228e6030791ac9667034a8d64d2b",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 131,
+          "bodySize": 118,
           "cookies": [],
           "headers": [
             {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "131"
-            },
-            {
-              "_fromType": "array",
               "name": "accept",
               "value": "application/json"
             },
             {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "Anthropic/JS 0.20.1"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-stainless-lang",
-              "value": "js"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-stainless-package-version",
-              "value": "0.20.1"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-stainless-os",
-              "value": "MacOS"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-stainless-arch",
-              "value": "arm64"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-stainless-runtime",
-              "value": "node"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-stainless-runtime-version",
-              "value": "v18.17.1"
-            },
-            {
-              "_fromType": "array",
               "name": "anthropic-version",
               "value": "2023-06-01"
             },
             {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
+              "name": "content-type",
+              "value": "application/json"
             },
             {
-              "name": "host",
-              "value": "api.anthropic.com"
+              "name": "user-agent",
+              "value": "Anthropic/JS 0.50.4"
+            },
+            {
+              "name": "x-stainless-arch",
+              "value": "arm64"
+            },
+            {
+              "name": "x-stainless-lang",
+              "value": "js"
+            },
+            {
+              "name": "x-stainless-os",
+              "value": "MacOS"
+            },
+            {
+              "name": "x-stainless-package-version",
+              "value": "0.50.4"
+            },
+            {
+              "name": "x-stainless-retry-count",
+              "value": "0"
+            },
+            {
+              "name": "x-stainless-runtime",
+              "value": "node"
+            },
+            {
+              "name": "x-stainless-runtime-version",
+              "value": "v22.10.0"
+            },
+            {
+              "name": "x-stainless-timeout",
+              "value": "600"
             }
           ],
-          "headersSize": 548,
+          "headersSize": 525,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\n  \"model\": \"claude-2\",\n  \"max_tokens_to_sample\": 300,\n  \"prompt\": \"\\n\\nHuman: Tell me a joke about OpenTelemetry\\n\\nAssistant:\"\n}"
+            "text": "{\"model\":\"claude-2\",\"max_tokens_to_sample\":300,\"prompt\":\"\\n\\nHuman: Tell me a joke about OpenTelemetry\\n\\nAssistant:\"}"
           },
           "queryString": [],
           "url": "https://api.anthropic.com/v1/complete"
         },
         "response": {
-          "bodySize": 600,
+          "bodySize": 776,
           "content": {
-            "encoding": "base64",
             "mimeType": "application/json",
-            "size": 600,
-            "text": "[\"H4sIAAAAAAAAA4xSwWobMRD9lWddfNmY2s0h+BLS9hBDIJdAWjCYyWpqqdZqttIoW7X034s2DSQlh14EmuG9efPm/TJaRzZb08swBlYv0XTG2+fK4d366qOupw2fX1R7MX7m8/c3m3u2pnsJ2Rpcc+JlBiF41cBo3aKc4MogCfQgRXE7crzjwANrqtt93Md7VzFRhjp+3YUm6hklOhrHeokP3FPJDK9wZBEFeaSYF43kNXDiqFCZKa302qZHi0zedtibT3Opww7qfDxhB0ePDBXBQLGil6j8Q/Nib9DI7yb5R1l7fZ8xUTjBRxUQHiitcBsZmWp+ni7qOLWZX6TgFGXqMDESUwgVPmZNZWhi+ZFTbWqOoCQlWjhOvNibJ4dIYQVVCnoKARTfdEod6TLjKJHRJ/pZL3GFWFTr7NRs1A5ORp6pgj+xxVCRfVNDqjyMmkGKb3Li/NbFVrhhxcDzLvBfG9HSzlRtZcfUrK4YJDGUexclyLGeqeOB7VMSFqYzWWU8JKY8R2f+Zf5eOPZsOjOI5dACGKhYPtus1n8hZjsbcl0GilvTmSDHw/9E9fcfAAAA//8DAOxCDkfmAgAA\"]"
+            "size": 776,
+            "text": "{\"type\":\"completion\",\"id\":\"compl_01MkPQy9DMgyJBBE1Z5FpHkf\",\"completion\":\" Here is an OpenTelemetry joke:\\n\\nWhy was the trace so hard to follow?\\nIt had no spans!\\n\\nIt's a play on words about OpenTelemetry spans, which are a fundamental concept in distributed tracing. The traces for an OpenTelemetry instrumented app consist of spans that allow you to follow the flow of execution across services. Without spans, it would be hard to understand the causal relationships and trace how a request propagates through the system.\\n\\nHope you enjoyed that little OpenTelemetry humor! Let me know if you'd like to hear another telemetry or observability related joke.\",\"stop_reason\":\"stop_sequence\",\"model\":\"claude-2.1\",\"stop\":\"\\n\\nHuman:\",\"log_id\":\"compl_01MkPQy9DMgyJBBE1Z5FpHkf\"}"
           },
           "cookies": [],
           "headers": [
             {
-              "name": "date",
-              "value": "Fri, 05 Apr 2024 11:20:12 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "keep-alive"
-            },
-            {
-              "name": "request-id",
-              "value": "req_01MF9Mk2Pm5K7idAdKGVuKtn"
-            },
-            {
-              "name": "x-cloud-trace-context",
-              "value": "bfd63b2c08c48c70d3ba04406af4864c"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google"
+              "name": "anthropic-organization-id",
+              "value": "4591fe84-abb6-4b93-9858-2c0c0b11204e"
             },
             {
               "name": "cf-cache-status",
               "value": "DYNAMIC"
             },
             {
-              "name": "server",
-              "value": "cloudflare"
+              "name": "cf-ray",
+              "value": "94d3d12f5858556e-EWR"
             },
             {
-              "name": "cf-ray",
-              "value": "86f925a33e42a268-FCO"
+              "name": "connection",
+              "value": "keep-alive"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Jun 2025 21:45:46 GMT"
+            },
+            {
+              "name": "request-id",
+              "value": "req_011CPyNzBf3pvguzANuUuKAW"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
             }
           ],
-          "headersSize": 339,
+          "headersSize": 440,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-05T11:20:06.759Z",
-        "time": 5267,
+        "startedDateTime": "2025-06-09T21:45:38.365Z",
+        "time": 8503,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,7 +152,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 5267
+          "wait": 8503
         }
       }
     ],

--- a/packages/instrumentation-anthropic/recordings/Test-Anthropic-instrumentation_3769946143/should-set-attributes-in-span-for-messages-streaming_44400664/recording.har
+++ b/packages/instrumentation-anthropic/recordings/Test-Anthropic-instrumentation_3769946143/should-set-attributes-in-span-for-messages-streaming_44400664/recording.har
@@ -8,152 +8,195 @@
     },
     "entries": [
       {
-        "_id": "169f6f7c83e96867124983806f6d7be4",
+        "_id": "790268f7c228733e3d4a492ea6ad87c6",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 188,
+          "bodySize": 142,
           "cookies": [],
           "headers": [
             {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "188"
-            },
-            {
-              "_fromType": "array",
               "name": "accept",
               "value": "application/json"
             },
             {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "Anthropic/JS 0.20.1"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-stainless-lang",
-              "value": "js"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-stainless-package-version",
-              "value": "0.20.1"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-stainless-os",
-              "value": "MacOS"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-stainless-arch",
-              "value": "arm64"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-stainless-runtime",
-              "value": "node"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-stainless-runtime-version",
-              "value": "v18.17.1"
-            },
-            {
-              "_fromType": "array",
               "name": "anthropic-version",
               "value": "2023-06-01"
             },
             {
-              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "Anthropic/JS 0.50.4"
+            },
+            {
+              "name": "x-stainless-arch",
+              "value": "arm64"
+            },
+            {
               "name": "x-stainless-helper-method",
               "value": "stream"
             },
             {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
+              "name": "x-stainless-lang",
+              "value": "js"
             },
             {
-              "name": "host",
-              "value": "api.anthropic.com"
+              "name": "x-stainless-os",
+              "value": "MacOS"
+            },
+            {
+              "name": "x-stainless-package-version",
+              "value": "0.50.4"
+            },
+            {
+              "name": "x-stainless-retry-count",
+              "value": "0"
+            },
+            {
+              "name": "x-stainless-runtime",
+              "value": "node"
+            },
+            {
+              "name": "x-stainless-runtime-version",
+              "value": "v22.10.0"
+            },
+            {
+              "name": "x-stainless-timeout",
+              "value": "600"
             }
           ],
-          "headersSize": 583,
+          "headersSize": 560,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\n  \"max_tokens\": 1024,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Tell me a joke about OpenTelemetry\"\n    }\n  ],\n  \"model\": \"claude-3-opus-20240229\",\n  \"stream\": true\n}"
+            "text": "{\"max_tokens\":1024,\"messages\":[{\"role\":\"user\",\"content\":\"Tell me a joke about OpenTelemetry\"}],\"model\":\"claude-3-opus-20240229\",\"stream\":true}"
           },
           "queryString": [],
           "url": "https://api.anthropic.com/v1/messages"
         },
         "response": {
-          "bodySize": 19048,
+          "bodySize": 8989,
           "content": {
             "mimeType": "text/event-stream; charset=utf-8",
-            "size": 19048,
-            "text": "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_01B1V5rsrrCx1gdMW82NDgHk\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"model\":\"claude-3-opus-20240229\",\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":17,\"output_tokens\":1}}               }\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}            }\n\nevent: ping\ndata: {\"type\": \"ping\"}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Sure\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"!\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" Here\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"'s\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" a\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" joke\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" about\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" Open\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"T\"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"el\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"emet\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"ry\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\":\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"\\n\\nWhy\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" did\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" the\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" developer\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" love\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" using\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" Open\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"T\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"el\"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"emet\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"ry\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"?\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"\\nBecause\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" it\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" made\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" tr\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"acing\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" their\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" code\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" a\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" \\\"\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"span\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"\\\"-\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"t\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"astic\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" experience\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"!\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"\\n\\nExplanation\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\":\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" Open\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"T\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"el\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"emet\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"ry\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" is\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" a\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" set\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" of\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" APIs\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\",\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" SD\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"K\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"s\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\",\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" and\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" tools\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" used\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" for\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" collecting\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" and\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" ex\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"porting\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" tel\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"emet\"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"ry\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" data\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" (\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"like\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" traces\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\",\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" metrics\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\",\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" and\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" logs\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\")\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" to\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" help\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" observe\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" and\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" monitor\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" distributed\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" systems\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\".\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" In\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" Open\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"T\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"el\"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"emet\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"ry\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\",\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" a\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" \\\"\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"span\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"\\\"\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" represents\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" a\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" single\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" operation\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" or\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" unit\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" of\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" work\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" within\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" a\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" trace\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\".\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" The\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" joke\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" plays\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" on\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" the\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" similarity\"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" between\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" the\"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" word\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" \\\"\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"span\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"\\\"\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" and\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" \\\"\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"fantastic\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\",\\\"\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" impl\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"ying\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" that\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" using\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" Open\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"T\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"el\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"emet\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"ry\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" makes\"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" tr\"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"acing\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" code\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" a\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" great\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" experience\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" for\"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" developers\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\".\"}    }\n\nevent: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0        }\n\nevent: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"output_tokens\":151}}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"       }\n\n"
+            "size": 8989,
+            "text": "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_0178nRhNdfNKxFcZRFqApVgL\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-3-opus-20240229\",\"content\":[],\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":17,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"output_tokens\":1,\"service_tier\":\"standard\"}}         }\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}          }\n\nevent: ping\ndata: {\"type\": \"ping\"}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Sure\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\", here's a\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" joke about OpenT\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"elemetry:\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"\\n\\nWhy did the\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" developer choose OpenTel\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"emetry for\"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" their distribute\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"d system\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"?\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"\\n\\nBecause they\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" wanted to trace\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" their\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" way\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" to\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" the root of all\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" evil!\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" \"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"😄\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"\\n\\nExplanation\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\": OpenTel\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"emetry is an\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" open-source observ\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"ability framework that provides\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" a\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" set\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" of APIs\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\",\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" libraries, and tools\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" to instrument\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\", generate, collect\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\", and export\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" tel\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"emetry data (\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"metrics, logs\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\", and traces) for\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" distributed systems. It\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" helps developers trace\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" and monitor the behavior\"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" and performance of their applications\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" across multiple services\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" an\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"d components\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\". The\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" joke plays\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" on the wor\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"d \\\"trace\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"\\\" as\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" a reference\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" to both\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" distribute\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"d tr\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"acing in\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" Open\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Telemetry\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" and the idi\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"om \\\"trace\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" something\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" to its\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" source or\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" origin.\\\"\"}             }\n\nevent: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0        }\n\nevent: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"output_tokens\":158}           }\n\nevent: message_stop\ndata: {\"type\":\"message_stop\" }\n\n"
           },
           "cookies": [],
           "headers": [
             {
-              "name": "date",
-              "value": "Fri, 05 Apr 2024 11:20:24 GMT"
+              "name": "anthropic-organization-id",
+              "value": "4591fe84-abb6-4b93-9858-2c0c0b11204e"
             },
             {
-              "name": "content-type",
-              "value": "text/event-stream; charset=utf-8"
+              "name": "anthropic-ratelimit-input-tokens-limit",
+              "value": "400000"
             },
             {
-              "name": "transfer-encoding",
-              "value": "chunked"
+              "name": "anthropic-ratelimit-input-tokens-remaining",
+              "value": "400000"
             },
             {
-              "name": "connection",
-              "value": "keep-alive"
+              "name": "anthropic-ratelimit-input-tokens-reset",
+              "value": "2025-06-09T21:46:40Z"
+            },
+            {
+              "name": "anthropic-ratelimit-output-tokens-limit",
+              "value": "80000"
+            },
+            {
+              "name": "anthropic-ratelimit-output-tokens-remaining",
+              "value": "80000"
+            },
+            {
+              "name": "anthropic-ratelimit-output-tokens-reset",
+              "value": "2025-06-09T21:46:40Z"
+            },
+            {
+              "name": "anthropic-ratelimit-requests-limit",
+              "value": "4000"
+            },
+            {
+              "name": "anthropic-ratelimit-requests-remaining",
+              "value": "3999"
+            },
+            {
+              "name": "anthropic-ratelimit-requests-reset",
+              "value": "2025-06-09T21:46:40Z"
+            },
+            {
+              "name": "anthropic-ratelimit-tokens-limit",
+              "value": "480000"
+            },
+            {
+              "name": "anthropic-ratelimit-tokens-remaining",
+              "value": "480000"
+            },
+            {
+              "name": "anthropic-ratelimit-tokens-reset",
+              "value": "2025-06-09T21:46:40Z"
             },
             {
               "name": "cache-control",
               "value": "no-cache"
             },
             {
-              "name": "request-id",
-              "value": "req_01MSkAn89zj7EbecovHP9E65"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google"
-            },
-            {
               "name": "cf-cache-status",
               "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "94d3d2b3ee054f4e-EWR"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-type",
+              "value": "text/event-stream; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Jun 2025 21:46:41 GMT"
+            },
+            {
+              "name": "request-id",
+              "value": "req_011CPyP4mVdYqDUHxqdFDszC"
             },
             {
               "name": "server",
               "value": "cloudflare"
             },
             {
-              "name": "cf-ray",
-              "value": "86f926063927a268-FCO"
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
             }
           ],
-          "headersSize": 299,
+          "headersSize": 1072,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-05T11:20:22.711Z",
-        "time": 9590,
+        "startedDateTime": "2025-06-09T21:46:40.594Z",
+        "time": 6025,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,7 +204,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 9590
+          "wait": 6025
         }
       }
     ],

--- a/packages/instrumentation-anthropic/recordings/Test-Anthropic-instrumentation_3769946143/should-set-attributes-in-span-for-messages_831758903/recording.har
+++ b/packages/instrumentation-anthropic/recordings/Test-Anthropic-instrumentation_3769946143/should-set-attributes-in-span-for-messages_831758903/recording.har
@@ -8,152 +8,191 @@
     },
     "entries": [
       {
-        "_id": "736e4bfd3852112815402bf773b26d6e",
+        "_id": "cd7c16f0f769021d379852b266a04072",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 170,
+          "bodySize": 128,
           "cookies": [],
           "headers": [
             {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "170"
-            },
-            {
-              "_fromType": "array",
               "name": "accept",
               "value": "application/json"
             },
             {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "Anthropic/JS 0.20.1"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-stainless-lang",
-              "value": "js"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-stainless-package-version",
-              "value": "0.20.1"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-stainless-os",
-              "value": "MacOS"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-stainless-arch",
-              "value": "arm64"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-stainless-runtime",
-              "value": "node"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-stainless-runtime-version",
-              "value": "v18.17.1"
-            },
-            {
-              "_fromType": "array",
               "name": "anthropic-version",
               "value": "2023-06-01"
             },
             {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
+              "name": "content-type",
+              "value": "application/json"
             },
             {
-              "name": "host",
-              "value": "api.anthropic.com"
+              "name": "user-agent",
+              "value": "Anthropic/JS 0.50.4"
+            },
+            {
+              "name": "x-stainless-arch",
+              "value": "arm64"
+            },
+            {
+              "name": "x-stainless-lang",
+              "value": "js"
+            },
+            {
+              "name": "x-stainless-os",
+              "value": "MacOS"
+            },
+            {
+              "name": "x-stainless-package-version",
+              "value": "0.50.4"
+            },
+            {
+              "name": "x-stainless-retry-count",
+              "value": "0"
+            },
+            {
+              "name": "x-stainless-runtime",
+              "value": "node"
+            },
+            {
+              "name": "x-stainless-runtime-version",
+              "value": "v22.10.0"
+            },
+            {
+              "name": "x-stainless-timeout",
+              "value": "600"
             }
           ],
-          "headersSize": 548,
+          "headersSize": 525,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\n  \"max_tokens\": 1024,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Tell me a joke about OpenTelemetry\"\n    }\n  ],\n  \"model\": \"claude-3-opus-20240229\"\n}"
+            "text": "{\"max_tokens\":1024,\"messages\":[{\"role\":\"user\",\"content\":\"Tell me a joke about OpenTelemetry\"}],\"model\":\"claude-3-opus-20240229\"}"
           },
           "queryString": [],
           "url": "https://api.anthropic.com/v1/messages"
         },
         "response": {
-          "bodySize": 736,
+          "bodySize": 911,
           "content": {
-            "encoding": "base64",
             "mimeType": "application/json",
-            "size": 736,
-            "text": "[\"H4sIAAAAAAAAA1RSX2vbMBD/Kle95MUpbdZR5pexQseS0Q220nUsI8jWJdYs37m6U10T+t2HnJWsT4a7+/2V98Y7U5pOdpuz8+un1erx56dvl6vP9/cPVzd0dacfr01hdOwxX6GI3aEpTOSQB1bEi1pSU5iaSZHUlL/2L/eKT3kzfUrzPUUsoMGIMwELf7hFsBUnha890i0G7FDjWK5pTR/A4SMG7jHCYEMr4EkZLFQ2giUHHB3GTOOip/YUbhvMO0VyGMFKKwWszQ9OwcHICYJvEZRB4wicIhAOr2XnlRV0IKModu9hqVBbAo22xkwQD4qwjdyBNggdd0g6cfchH3md+I8rrzMBwfiI7mRtcqps8pgrYh88Tj6/ZKClbHoJfcQtRujGQzbJtBVCosmMm+InclynLIPuFJbgmGYKgyXNuIplQrXEAzQ8QJfqBpazDqRHcp52wAQ21NxwAJdingwcW2g4RfnP7bHSYNOukUlc7Di5XsIuoUjuYBYRiBUiWjfCliNwlaPbygevI3g6lDglymqNrbwKjKincGPHCkHU1+1LhRzcfGul8UzoYLAj8PbwAhn8r5fspeE+T7JixlUoerI25vl3YTp2GExp6mCTw/mbOfdJ5ouzxcXZYvHOFEaU+01EK0ymNEhuoynSy0LwISHVaEpKIRQmTb9+uTee+qQb5RZJTHl+WRhO+mr09uL5+S8AAAD//wMACb+NKFkDAAA=\"]"
+            "size": 911,
+            "text": "{\"id\":\"msg_01ABEG1nJ4BqCbQR4BUANnCB\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-3-opus-20240229\",\"content\":[{\"type\":\"text\",\"text\":\"Sure! Here's a joke about OpenTelemetry:\\n\\nWhy did the developer choose OpenTelemetry for their distributed system?\\n\\nBecause they wanted to trace their way to success!\\n\\nExplanation: OpenTelemetry is an open-source observability framework that provides a standard way to collect and export telemetry data (metrics, logs, and traces) from distributed systems. The joke plays on the word \\\"trace,\\\" which is a key concept in OpenTelemetry, and the idea of tracing one's way to success, implying that using OpenTelemetry can help developers better understand and optimize their systems.\"}],\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":17,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"output_tokens\":137,\"service_tier\":\"standard\"}}"
           },
           "cookies": [],
           "headers": [
             {
-              "name": "date",
-              "value": "Fri, 05 Apr 2024 11:20:22 GMT"
+              "name": "anthropic-organization-id",
+              "value": "4591fe84-abb6-4b93-9858-2c0c0b11204e"
             },
             {
-              "name": "content-type",
-              "value": "application/json"
+              "name": "anthropic-ratelimit-input-tokens-limit",
+              "value": "400000"
             },
             {
-              "name": "transfer-encoding",
-              "value": "chunked"
+              "name": "anthropic-ratelimit-input-tokens-remaining",
+              "value": "400000"
             },
             {
-              "name": "connection",
-              "value": "keep-alive"
+              "name": "anthropic-ratelimit-input-tokens-reset",
+              "value": "2025-06-09T21:46:35Z"
             },
             {
-              "name": "request-id",
-              "value": "req_0182vaPgMhnXsMnBS73p6Yqd"
+              "name": "anthropic-ratelimit-output-tokens-limit",
+              "value": "80000"
             },
             {
-              "name": "x-cloud-trace-context",
-              "value": "42ba21496f6152a6803a8a29a8855cd7"
+              "name": "anthropic-ratelimit-output-tokens-remaining",
+              "value": "80000"
             },
             {
-              "name": "via",
-              "value": "1.1 google"
+              "name": "anthropic-ratelimit-output-tokens-reset",
+              "value": "2025-06-09T21:46:40Z"
+            },
+            {
+              "name": "anthropic-ratelimit-requests-limit",
+              "value": "4000"
+            },
+            {
+              "name": "anthropic-ratelimit-requests-remaining",
+              "value": "3999"
+            },
+            {
+              "name": "anthropic-ratelimit-requests-reset",
+              "value": "2025-06-09T21:46:34Z"
+            },
+            {
+              "name": "anthropic-ratelimit-tokens-limit",
+              "value": "480000"
+            },
+            {
+              "name": "anthropic-ratelimit-tokens-remaining",
+              "value": "480000"
+            },
+            {
+              "name": "anthropic-ratelimit-tokens-reset",
+              "value": "2025-06-09T21:46:35Z"
             },
             {
               "name": "cf-cache-status",
               "value": "DYNAMIC"
             },
             {
-              "name": "server",
-              "value": "cloudflare"
+              "name": "cf-ray",
+              "value": "94d3d28cadcb4f4e-EWR"
             },
             {
-              "name": "cf-ray",
-              "value": "86f925d0bb53a268-FCO"
+              "name": "connection",
+              "value": "keep-alive"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Jun 2025 21:46:40 GMT"
+            },
+            {
+              "name": "request-id",
+              "value": "req_011CPyP4KPVnPApMkoT38qVm"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
             }
           ],
-          "headersSize": 339,
+          "headersSize": 1055,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-05T11:20:14.137Z",
-        "time": 8561,
+        "startedDateTime": "2025-06-09T21:46:34.311Z",
+        "time": 6280,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,7 +200,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 8561
+          "wait": 6280
         }
       }
     ],

--- a/packages/traceloop-sdk/package.json
+++ b/packages/traceloop-sdk/package.json
@@ -62,7 +62,7 @@
   "gitHead": "ef1e70d6037f7b5c061056ef2be16e3f55f02ed5",
   "devDependencies": {
     "@ai-sdk/openai": "^1.0.10",
-    "@anthropic-ai/sdk": "^0.32.1",
+    "@anthropic-ai/sdk": "^0.50.4",
     "@aws-sdk/client-bedrock-runtime": "^3.709.0",
     "@azure/openai": "^1.0.0-beta.13",
     "@google-cloud/aiplatform": "^3.34.0",


### PR DESCRIPTION
 - enables the mostly-finished streaming chat completion support in the implementation and tests
 - supports newer series of Anthropic SDKs which use overriden Promise classes and Stream classes, which break the current version of the instrumentation's approach to wrapping streaming


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Upgrade Anthropic SDK to v0.50.4 and update instrumentation for new streaming capabilities.
> 
>   - **SDK Update**:
>     - Upgrades `@anthropic-ai/sdk` from `^0.32.1` to `^0.50.4` in `package.json`.
>   - **Instrumentation Changes**:
>     - Updates `patchAnthropic()` in `instrumentation.ts` to handle new `APIPromise` and `Stream` classes.
>     - Modifies `_streamingWrapPromise()` to support new streaming chat completion.
>     - Adjusts `patch()` and `unpatch()` methods to accommodate SDK changes.
>   - **Testing**:
>     - Enables previously skipped test for streaming messages in `instrumentation.test.ts`.
>     - Updates test cases to reflect new model names and streaming behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry-js&utm_source=github&utm_medium=referral)<sup> for 8322a205fefa692a9e5cbcbcf1c0b31705d994cd. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->