### PR TITLE
feat(otel): general bump to v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13189,405 +13189,458 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.56.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.56.0.tgz",
-      "integrity": "sha512-Wr39+94UNNG3Ei9nv3pHd4AJ63gq5nSemMRpCd8fPwDL9rN3vK26lzxfH27mw16XzOSO+TpyQwBAMaLxaPWG0g==",
-      "license": "Apache-2.0",
+      "version": "0.202.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.202.0.tgz",
+      "integrity": "sha512-fTBjMqKCfotFWfLzaKyhjLvyEyq5vDKTTFfBmx21btv3gvy8Lq6N5Dh2OzqeuN4DjtpSvNT1uNVfg08eD2Rfxw==",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.29.0.tgz",
-      "integrity": "sha512-TKT91jcFXgHyIDF1lgJF3BHGIakn6x0Xp7Tq3zoS3TMPzT9IlP0xEavWP8C1zGjU9UmZP2VR1tJhW9Az1A3w8Q==",
-      "license": "Apache-2.0",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.0.1.tgz",
+      "integrity": "sha512-XuY23lSI3d4PEqKA+7SLtAgwqIfc6E/E9eAQWLN1vlpC53ybO3o6jW4BsXo1xvz9lYyyWItfQDDLzezER01mCw==",
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.29.0.tgz",
-      "integrity": "sha512-gmT7vAreXl0DTHD2rVZcw3+l2g84+5XiHIqdBUxXbExymPCvSsGOpiwMmn8nkiJur28STV31wnhIDrzWDPzjfA==",
-      "license": "Apache-2.0",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
+      "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.28.0"
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-grpc": {
-      "version": "0.56.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.56.0.tgz",
-      "integrity": "sha512-/ef8wcphVKZ0uI7A1oqQI/gEMiBUlkeBkM9AGx6AviQFIbgPVSdNK3+bHBkyq5qMkyWgkeQCSJ0uhc5vJpf0dw==",
-      "license": "Apache-2.0",
+      "version": "0.202.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.202.0.tgz",
+      "integrity": "sha512-Y84L8Yja/A2qjGEzC/To0yrMUXHrtwJzHtZ2za1/ulZplRe5QFsLNyHixIS42ZYUKuNyWMDgOFhnN2Pz5uThtg==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.29.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.56.0",
-        "@opentelemetry/otlp-transformer": "0.56.0",
-        "@opentelemetry/sdk-logs": "0.56.0"
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/otlp-exporter-base": "0.202.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.202.0",
+        "@opentelemetry/otlp-transformer": "0.202.0",
+        "@opentelemetry/sdk-logs": "0.202.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-http": {
-      "version": "0.56.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.56.0.tgz",
-      "integrity": "sha512-gN/itg2B30pa+yAqiuIHBCf3E77sSBlyWVzb+U/MDLzEMOwfnexlMvOWULnIO1l2xR2MNLEuPCQAOrL92JHEJg==",
-      "license": "Apache-2.0",
+      "version": "0.202.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.202.0.tgz",
+      "integrity": "sha512-mJWLkmoG+3r+SsYQC+sbWoy1rjowJhMhFvFULeIPTxSI+EZzKPya0+NZ3+vhhgx2UTybGQlye3FBtCH3o6Rejg==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.56.0",
-        "@opentelemetry/core": "1.29.0",
-        "@opentelemetry/otlp-exporter-base": "0.56.0",
-        "@opentelemetry/otlp-transformer": "0.56.0",
-        "@opentelemetry/sdk-logs": "0.56.0"
+        "@opentelemetry/api-logs": "0.202.0",
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/otlp-exporter-base": "0.202.0",
+        "@opentelemetry/otlp-transformer": "0.202.0",
+        "@opentelemetry/sdk-logs": "0.202.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
-      "version": "0.56.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.56.0.tgz",
-      "integrity": "sha512-MaO+eGrdksd8MpEbDDLbWegHc3w6ualZV6CENxNOm3wqob0iOx78/YL2NVIKyP/0ktTUIs7xIppUYqfY3ogFLQ==",
-      "license": "Apache-2.0",
+      "version": "0.202.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.202.0.tgz",
+      "integrity": "sha512-qYwbmNWPkP7AbzX8o4DRu5bb/a0TWYNcpZc1NEAOhuV7pgBpAUPEClxRWPN94ulIia+PfQjzFGMaRwmLGmNP6g==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.56.0",
-        "@opentelemetry/core": "1.29.0",
-        "@opentelemetry/otlp-exporter-base": "0.56.0",
-        "@opentelemetry/otlp-transformer": "0.56.0",
-        "@opentelemetry/resources": "1.29.0",
-        "@opentelemetry/sdk-logs": "0.56.0",
-        "@opentelemetry/sdk-trace-base": "1.29.0"
+        "@opentelemetry/api-logs": "0.202.0",
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/otlp-exporter-base": "0.202.0",
+        "@opentelemetry/otlp-transformer": "0.202.0",
+        "@opentelemetry/resources": "2.0.1",
+        "@opentelemetry/sdk-logs": "0.202.0",
+        "@opentelemetry/sdk-trace-base": "2.0.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
+      "version": "0.202.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.202.0.tgz",
+      "integrity": "sha512-/dq/rf4KCkTYoP+NyPXTE+5wjvfhAHSqK62vRsJ/IalG61VPQvwaL18yWcavbI+44ImQwtMeZxfIJSox7oQL0w==",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.7.1",
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.202.0",
+        "@opentelemetry/otlp-exporter-base": "0.202.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.202.0",
+        "@opentelemetry/otlp-transformer": "0.202.0",
+        "@opentelemetry/resources": "2.0.1",
+        "@opentelemetry/sdk-metrics": "2.0.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
+      "version": "0.202.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.202.0.tgz",
+      "integrity": "sha512-ooYcrf/m9ZuVGpQnER7WRH+JZbDPD389HG7VS/EnvIEF5WpNYEqf+NdmtaAcs51d81QrytTYAubc5bVWi//28w==",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/otlp-exporter-base": "0.202.0",
+        "@opentelemetry/otlp-transformer": "0.202.0",
+        "@opentelemetry/resources": "2.0.1",
+        "@opentelemetry/sdk-metrics": "2.0.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
+      "version": "0.202.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.202.0.tgz",
+      "integrity": "sha512-X0RpPpPjyCAmIq9tySZm0Hk3Ltw8KWsqeNq5I7gS9AR9RzbVHb/l+eiMI1CqSRvW9R47HXcUu/epmEzY8ebFAg==",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.202.0",
+        "@opentelemetry/otlp-exporter-base": "0.202.0",
+        "@opentelemetry/otlp-transformer": "0.202.0",
+        "@opentelemetry/resources": "2.0.1",
+        "@opentelemetry/sdk-metrics": "2.0.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-prometheus": {
+      "version": "0.202.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.202.0.tgz",
+      "integrity": "sha512-6RvQqZHAPFiwL1OKRJe4ta6SgJx/g8or41B+OovVVEie3HeCDhDGL9S1VJNkBozUz6wTY8a47fQwdMrCOUdMhQ==",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/resources": "2.0.1",
+        "@opentelemetry/sdk-metrics": "2.0.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.56.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.56.0.tgz",
-      "integrity": "sha512-9hRHue78CV2XShAt30HadBK8XEtOBiQmnkYquR1RQyf2RYIdJvhiypEZ+Jh3NGW8Qi14icTII/1oPTQlhuyQdQ==",
-      "license": "Apache-2.0",
+      "version": "0.202.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.202.0.tgz",
+      "integrity": "sha512-d5wLdbNA3ahpSeD0I34vbDFMTh4vPsXemH0bKDXLeCVULCAjOJXuZmEiuRammiDgVvvX7CAb/IGLDz8d2QHvoA==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.29.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.56.0",
-        "@opentelemetry/otlp-transformer": "0.56.0",
-        "@opentelemetry/resources": "1.29.0",
-        "@opentelemetry/sdk-trace-base": "1.29.0"
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/otlp-exporter-base": "0.202.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.202.0",
+        "@opentelemetry/otlp-transformer": "0.202.0",
+        "@opentelemetry/resources": "2.0.1",
+        "@opentelemetry/sdk-trace-base": "2.0.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.56.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.56.0.tgz",
-      "integrity": "sha512-vqVuJvcwameA0r0cNrRzrZqPLB0otS+95g0XkZdiKOXUo81wYdY6r4kyrwz4nSChqTBEFm0lqi/H2OWGboOa6g==",
-      "license": "Apache-2.0",
+      "version": "0.202.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.202.0.tgz",
+      "integrity": "sha512-/hKE8DaFCJuaQqE1IxpgkcjOolUIwgi3TgHElPVKGdGRBSmJMTmN/cr6vWa55pCJIXPyhKvcMrbrya7DZ3VmzA==",
       "dependencies": {
-        "@opentelemetry/core": "1.29.0",
-        "@opentelemetry/otlp-exporter-base": "0.56.0",
-        "@opentelemetry/otlp-transformer": "0.56.0",
-        "@opentelemetry/resources": "1.29.0",
-        "@opentelemetry/sdk-trace-base": "1.29.0"
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/otlp-exporter-base": "0.202.0",
+        "@opentelemetry/otlp-transformer": "0.202.0",
+        "@opentelemetry/resources": "2.0.1",
+        "@opentelemetry/sdk-trace-base": "2.0.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.56.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.56.0.tgz",
-      "integrity": "sha512-UYVtz8Kp1QZpZFg83ZrnwRIxF2wavNyi1XaIKuQNFjlYuGCh8JH4+GOuHUU4G8cIzOkWdjNR559vv0Q+MCz+1w==",
-      "license": "Apache-2.0",
+      "version": "0.202.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.202.0.tgz",
+      "integrity": "sha512-z3vzdMclCETGIn8uUBgpz7w651ftCiH2qh3cewhBk+rF0EYPNQ3mJvyxktLnKIBZ/ci0zUknAzzYC7LIIZmggQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.29.0",
-        "@opentelemetry/otlp-exporter-base": "0.56.0",
-        "@opentelemetry/otlp-transformer": "0.56.0",
-        "@opentelemetry/resources": "1.29.0",
-        "@opentelemetry/sdk-trace-base": "1.29.0"
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/otlp-exporter-base": "0.202.0",
+        "@opentelemetry/otlp-transformer": "0.202.0",
+        "@opentelemetry/resources": "2.0.1",
+        "@opentelemetry/sdk-trace-base": "2.0.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/exporter-zipkin": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.29.0.tgz",
-      "integrity": "sha512-9wNUxbl/sju2AvA3UhL2kLF1nfhJ4dVJgvktc3hx80Bg/fWHvF6ik4R3woZ/5gYFqZ97dcuik0dWPQEzLPNBtg==",
-      "license": "Apache-2.0",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-2.0.1.tgz",
+      "integrity": "sha512-a9eeyHIipfdxzCfc2XPrE+/TI3wmrZUDFtG2RRXHSbZZULAny7SyybSvaDvS77a7iib5MPiAvluwVvbGTsHxsw==",
       "dependencies": {
-        "@opentelemetry/core": "1.29.0",
-        "@opentelemetry/resources": "1.29.0",
-        "@opentelemetry/sdk-trace-base": "1.29.0",
-        "@opentelemetry/semantic-conventions": "1.28.0"
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/resources": "2.0.1",
+        "@opentelemetry/sdk-trace-base": "2.0.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.56.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.56.0.tgz",
-      "integrity": "sha512-2KkGBKE+FPXU1F0zKww+stnlUxUTlBvLCiWdP63Z9sqXYeNI/ziNzsxAp4LAdUcTQmXjw1IWgvm5CAb/BHy99w==",
-      "license": "Apache-2.0",
+      "version": "0.202.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.202.0.tgz",
+      "integrity": "sha512-Uz3BxZWPgDwgHM2+vCKEQRh0R8WKrd/q6Tus1vThRClhlPO39Dyz7mDrOr6KuqGXAlBQ1e5Tnymzri4RMZNaWA==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.56.0",
-        "@types/shimmer": "^1.2.0",
+        "@opentelemetry/api-logs": "0.202.0",
         "import-in-the-middle": "^1.8.1",
-        "require-in-the-middle": "^7.1.1",
-        "semver": "^7.5.2",
-        "shimmer": "^1.2.1"
+        "require-in-the-middle": "^7.1.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.56.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.56.0.tgz",
-      "integrity": "sha512-eURvv0fcmBE+KE1McUeRo+u0n18ZnUeSc7lDlW/dzlqFYasEbsztTK4v0Qf8C4vEY+aMTjPKUxBG0NX2Te3Pmw==",
-      "license": "Apache-2.0",
+      "version": "0.202.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.202.0.tgz",
+      "integrity": "sha512-nMEOzel+pUFYuBJg2znGmHJWbmvMbdX5/RhoKNKowguMbURhz0fwik5tUKplLcUtl8wKPL1y9zPnPxeBn65N0Q==",
       "dependencies": {
-        "@opentelemetry/core": "1.29.0",
-        "@opentelemetry/otlp-transformer": "0.56.0"
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/otlp-transformer": "0.202.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.56.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.56.0.tgz",
-      "integrity": "sha512-QqM4si8Ew8CW5xVk4mYbfusJzMXyk6tkYA5SI0w/5NBxmiZZaYPwQQ2cu58XUH2IMPAsi71yLJVJQaWBBCta0A==",
-      "license": "Apache-2.0",
+      "version": "0.202.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.202.0.tgz",
+      "integrity": "sha512-yIEHVxFA5dmYif7lZbbB66qulLLhrklj6mI2X3cuGW5hYPyUErztEmbroM+6teu/XobBi9bLHid2VT4NIaRuGg==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.29.0",
-        "@opentelemetry/otlp-exporter-base": "0.56.0",
-        "@opentelemetry/otlp-transformer": "0.56.0"
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/otlp-exporter-base": "0.202.0",
+        "@opentelemetry/otlp-transformer": "0.202.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.56.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.56.0.tgz",
-      "integrity": "sha512-kVkH/W2W7EpgWWpyU5VnnjIdSD7Y7FljQYObAQSKdRcejiwMj2glypZtUdfq1LTJcv4ht0jyTrw1D3CCxssNtQ==",
-      "license": "Apache-2.0",
+      "version": "0.202.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.202.0.tgz",
+      "integrity": "sha512-5XO77QFzs9WkexvJQL9ksxL8oVFb/dfi9NWQSq7Sv0Efr9x3N+nb1iklP1TeVgxqJ7m1xWiC/Uv3wupiQGevMw==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.56.0",
-        "@opentelemetry/core": "1.29.0",
-        "@opentelemetry/resources": "1.29.0",
-        "@opentelemetry/sdk-logs": "0.56.0",
-        "@opentelemetry/sdk-metrics": "1.29.0",
-        "@opentelemetry/sdk-trace-base": "1.29.0",
+        "@opentelemetry/api-logs": "0.202.0",
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/resources": "2.0.1",
+        "@opentelemetry/sdk-logs": "0.202.0",
+        "@opentelemetry/sdk-metrics": "2.0.1",
+        "@opentelemetry/sdk-trace-base": "2.0.1",
         "protobufjs": "^7.3.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/propagator-b3": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.29.0.tgz",
-      "integrity": "sha512-ktsNDlqhu+/IPGEJRMj81upg2JupUp+SwW3n1ZVZTnrDiYUiMUW41vhaziA7Q6UDhbZvZ58skDpQhe2ZgNIPvg==",
-      "license": "Apache-2.0",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-2.0.1.tgz",
+      "integrity": "sha512-Hc09CaQ8Tf5AGLmf449H726uRoBNGPBL4bjr7AnnUpzWMvhdn61F78z9qb6IqB737TffBsokGAK1XykFEZ1igw==",
       "dependencies": {
-        "@opentelemetry/core": "1.29.0"
+        "@opentelemetry/core": "2.0.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.29.0.tgz",
-      "integrity": "sha512-EXIEYmFgybnFMijVgqx1mq/diWwSQcd0JWVksytAVQEnAiaDvP45WuncEVQkFIAC0gVxa2+Xr8wL5pF5jCVKbg==",
-      "license": "Apache-2.0",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.0.1.tgz",
+      "integrity": "sha512-7PMdPBmGVH2eQNb/AtSJizQNgeNTfh6jQFqys6lfhd6P4r+m/nTh3gKPPpaCXVdRQ+z93vfKk+4UGty390283w==",
       "dependencies": {
-        "@opentelemetry/core": "1.29.0"
+        "@opentelemetry/core": "2.0.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.29.0.tgz",
-      "integrity": "sha512-s7mLXuHZE7RQr1wwweGcaRp3Q4UJJ0wazeGlc/N5/XSe6UyXfsh1UQGMADYeg7YwD+cEdMtU1yJAUXdnFzYzyQ==",
-      "license": "Apache-2.0",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.1.tgz",
+      "integrity": "sha512-dZOB3R6zvBwDKnHDTB4X1xtMArB/d324VsbiPkX/Yu0Q8T2xceRthoIVFhJdvgVM2QhGVUyX9tzwiNxGtoBJUw==",
       "dependencies": {
-        "@opentelemetry/core": "1.29.0",
-        "@opentelemetry/semantic-conventions": "1.28.0"
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.56.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.56.0.tgz",
-      "integrity": "sha512-OS0WPBJF++R/cSl+terUjQH5PebloidB1Jbbecgg2rnCmQbTST9xsRes23bLfDQVRvmegmHqDh884h0aRdJyLw==",
-      "license": "Apache-2.0",
+      "version": "0.202.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.202.0.tgz",
+      "integrity": "sha512-pv8QiQLQzk4X909YKm0lnW4hpuQg4zHwJ4XBd5bZiXcd9urvrJNoNVKnxGHPiDVX/GiLFvr5DMYsDBQbZCypRQ==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.56.0",
-        "@opentelemetry/core": "1.29.0",
-        "@opentelemetry/resources": "1.29.0"
+        "@opentelemetry/api-logs": "0.202.0",
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/resources": "2.0.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.4.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.29.0.tgz",
-      "integrity": "sha512-MkVtuzDjXZaUJSuJlHn6BSXjcQlMvHcsDV7LjY4P6AJeffMa4+kIGDjzsCf6DkAh6Vqlwag5EWEam3KZOX5Drw==",
-      "license": "Apache-2.0",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.0.1.tgz",
+      "integrity": "sha512-wf8OaJoSnujMAHWR3g+/hGvNcsC16rf9s1So4JlMiFaFHiE4HpIA3oUh+uWZQ7CNuK8gVW/pQSkgoa5HkkOl0g==",
       "dependencies": {
-        "@opentelemetry/core": "1.29.0",
-        "@opentelemetry/resources": "1.29.0"
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/resources": "2.0.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-node": {
-      "version": "0.56.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.56.0.tgz",
-      "integrity": "sha512-FOY7tWboBBxqftLNHPJFmDXo9fRoPd2PlzfEvSd6058BJM9gY4pWCg8lbVlu03aBrQjcfCTAhXk/tz1Yqd/m6g==",
-      "license": "Apache-2.0",
+      "version": "0.202.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.202.0.tgz",
+      "integrity": "sha512-SF9vXWVd9I5CZ69mW3GfwfLI2SHgyvEqntcg0en5y8kRp5+2PPoa3Mkgj0WzFLrbSgTw4PsXn7c7H6eSdrtV0w==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.56.0",
-        "@opentelemetry/core": "1.29.0",
-        "@opentelemetry/exporter-logs-otlp-grpc": "0.56.0",
-        "@opentelemetry/exporter-logs-otlp-http": "0.56.0",
-        "@opentelemetry/exporter-logs-otlp-proto": "0.56.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.56.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.56.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.56.0",
-        "@opentelemetry/exporter-zipkin": "1.29.0",
-        "@opentelemetry/instrumentation": "0.56.0",
-        "@opentelemetry/resources": "1.29.0",
-        "@opentelemetry/sdk-logs": "0.56.0",
-        "@opentelemetry/sdk-metrics": "1.29.0",
-        "@opentelemetry/sdk-trace-base": "1.29.0",
-        "@opentelemetry/sdk-trace-node": "1.29.0",
-        "@opentelemetry/semantic-conventions": "1.28.0"
+        "@opentelemetry/api-logs": "0.202.0",
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/exporter-logs-otlp-grpc": "0.202.0",
+        "@opentelemetry/exporter-logs-otlp-http": "0.202.0",
+        "@opentelemetry/exporter-logs-otlp-proto": "0.202.0",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "0.202.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.202.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "0.202.0",
+        "@opentelemetry/exporter-prometheus": "0.202.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.202.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.202.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.202.0",
+        "@opentelemetry/exporter-zipkin": "2.0.1",
+        "@opentelemetry/instrumentation": "0.202.0",
+        "@opentelemetry/propagator-b3": "2.0.1",
+        "@opentelemetry/propagator-jaeger": "2.0.1",
+        "@opentelemetry/resources": "2.0.1",
+        "@opentelemetry/sdk-logs": "0.202.0",
+        "@opentelemetry/sdk-metrics": "2.0.1",
+        "@opentelemetry/sdk-trace-base": "2.0.1",
+        "@opentelemetry/sdk-trace-node": "2.0.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.29.0.tgz",
-      "integrity": "sha512-hEOpAYLKXF3wGJpXOtWsxEtqBgde0SCv+w+jvr3/UusR4ll3QrENEGnSl1WDCyRrpqOQ5NCNOvZch9UFVa7MnQ==",
-      "license": "Apache-2.0",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.1.tgz",
+      "integrity": "sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.29.0",
-        "@opentelemetry/resources": "1.29.0",
-        "@opentelemetry/semantic-conventions": "1.28.0"
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/resources": "2.0.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.29.0.tgz",
-      "integrity": "sha512-ZpGYt+VnMu6O0SRKzhuIivr7qJm3GpWnTCMuJspu4kt3QWIpIenwixo5Vvjuu3R4h2Onl/8dtqAiPIs92xd5ww==",
-      "license": "Apache-2.0",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.0.1.tgz",
+      "integrity": "sha512-UhdbPF19pMpBtCWYP5lHbTogLWx9N0EBxtdagvkn5YtsAnCBZzL7SjktG+ZmupRgifsHMjwUaCCaVmqGfSADmA==",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.29.0",
-        "@opentelemetry/core": "1.29.0",
-        "@opentelemetry/propagator-b3": "1.29.0",
-        "@opentelemetry/propagator-jaeger": "1.29.0",
-        "@opentelemetry/sdk-trace-base": "1.29.0",
-        "semver": "^7.5.2"
+        "@opentelemetry/context-async-hooks": "2.0.1",
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/sdk-trace-base": "2.0.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-      "license": "Apache-2.0",
+      "version": "1.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.34.0.tgz",
+      "integrity": "sha512-aKcOkyrorBGlajjRdVoJWHTxfxO1vCNHLJVlSDaRHDIdjU+pX8IYQPvPDkYiujKLbRnWU+1TBwEt0QRgSm4SGA==",
       "engines": {
         "node": ">=14"
       }
@@ -15398,12 +15451,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/shimmer": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
-      "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
-      "license": "MIT"
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
@@ -28549,12 +28596,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/shimmer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
-      "license": "BSD-2-Clause"
-    },
     "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -30905,9 +30946,9 @@
       "version": "0.13.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "^1.29.0",
-        "@opentelemetry/instrumentation": "^0.56.0",
-        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "@opentelemetry/core": "^2.0.1",
+        "@opentelemetry/instrumentation": "^0.202.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0",
         "@traceloop/ai-semantic-conventions": "^0.13.0",
         "tslib": "^2.8.1"
       },
@@ -30928,9 +30969,9 @@
       "version": "0.13.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "^1.29.0",
-        "@opentelemetry/instrumentation": "^0.56.0",
-        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "@opentelemetry/core": "^2.0.1",
+        "@opentelemetry/instrumentation": "^0.202.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0",
         "@traceloop/ai-semantic-conventions": "^0.13.0",
         "tslib": "^2.8.1"
       },
@@ -30951,9 +30992,9 @@
       "version": "0.13.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "^1.29.0",
-        "@opentelemetry/instrumentation": "^0.56.0",
-        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "@opentelemetry/core": "^2.0.1",
+        "@opentelemetry/instrumentation": "^0.202.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0",
         "@traceloop/ai-semantic-conventions": "^0.13.0",
         "tslib": "^2.8.1"
       },
@@ -30972,9 +31013,9 @@
       "version": "0.13.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "^1.29.0",
-        "@opentelemetry/instrumentation": "^0.56.0",
-        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "@opentelemetry/core": "^2.0.1",
+        "@opentelemetry/instrumentation": "^0.202.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0",
         "@traceloop/ai-semantic-conventions": "^0.13.0",
         "tslib": "^2.8.1"
       },
@@ -30993,9 +31034,9 @@
       "version": "0.13.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "^1.29.0",
-        "@opentelemetry/instrumentation": "^0.56.0",
-        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "@opentelemetry/core": "^2.0.1",
+        "@opentelemetry/instrumentation": "^0.202.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0",
         "@traceloop/ai-semantic-conventions": "^0.13.0",
         "tslib": "^2.8.1"
       },
@@ -31014,9 +31055,9 @@
       "version": "0.13.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "^1.29.0",
-        "@opentelemetry/instrumentation": "^0.56.0",
-        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "@opentelemetry/core": "^2.0.1",
+        "@opentelemetry/instrumentation": "^0.202.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0",
         "@traceloop/ai-semantic-conventions": "^0.13.0",
         "tslib": "^2.8.1"
       },
@@ -31846,9 +31887,9 @@
       "version": "0.13.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "^1.29.0",
-        "@opentelemetry/instrumentation": "^0.56.0",
-        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "@opentelemetry/core": "^2.0.1",
+        "@opentelemetry/instrumentation": "^0.202.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0",
         "@traceloop/ai-semantic-conventions": "^0.13.0",
         "lodash": "^4.17.21",
         "tslib": "^2.8.1"
@@ -31870,9 +31911,9 @@
       "version": "0.13.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "^1.29.0",
-        "@opentelemetry/instrumentation": "^0.56.0",
-        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "@opentelemetry/core": "^2.0.1",
+        "@opentelemetry/instrumentation": "^0.202.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0",
         "@traceloop/ai-semantic-conventions": "^0.13.0",
         "js-tiktoken": "^1.0.15",
         "tslib": "^2.8.1"
@@ -31895,9 +31936,9 @@
       "version": "0.13.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "^1.29.0",
-        "@opentelemetry/instrumentation": "^0.56.0",
-        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "@opentelemetry/core": "^2.0.1",
+        "@opentelemetry/instrumentation": "^0.202.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0",
         "@traceloop/ai-semantic-conventions": "^0.13.0",
         "tslib": "^2.8.1"
       },
@@ -31916,8 +31957,8 @@
       "version": "0.13.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "^1.29.0",
-        "@opentelemetry/instrumentation": "^0.56.0",
+        "@opentelemetry/core": "^2.0.1",
+        "@opentelemetry/instrumentation": "^0.202.0",
         "@traceloop/ai-semantic-conventions": "^0.13.0",
         "tslib": "^2.8.1"
       },
@@ -31951,9 +31992,9 @@
       "version": "0.13.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "^1.29.0",
-        "@opentelemetry/instrumentation": "^0.56.0",
-        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "@opentelemetry/core": "^2.0.1",
+        "@opentelemetry/instrumentation": "^0.202.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0",
         "@traceloop/ai-semantic-conventions": "^0.13.0",
         "js-tiktoken": "^1.0.15",
         "tslib": "^2.8.1"
@@ -31976,9 +32017,9 @@
       "version": "0.13.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "^1.29.0",
-        "@opentelemetry/instrumentation": "^0.56.0",
-        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "@opentelemetry/core": "^2.0.1",
+        "@opentelemetry/instrumentation": "^0.202.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0",
         "@traceloop/ai-semantic-conventions": "^0.13.0",
         "tslib": "^2.8.1"
       },
@@ -32808,8 +32849,8 @@
       "version": "0.13.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/exporter-trace-otlp-proto": "^0.56.0",
-        "@opentelemetry/sdk-node": "^0.56.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "^0.202.0",
+        "@opentelemetry/sdk-node": "^0.202.0",
         "@traceloop/ai-semantic-conventions": "^0.13.0",
         "@traceloop/instrumentation-anthropic": "^0.13.0",
         "@traceloop/instrumentation-azure": "^0.13.0",

--- a/packages/instrumentation-anthropic/package.json
+++ b/packages/instrumentation-anthropic/package.json
@@ -38,9 +38,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "^1.29.0",
-    "@opentelemetry/instrumentation": "^0.56.0",
-    "@opentelemetry/semantic-conventions": "^1.28.0",
+    "@opentelemetry/core": "^2.0.1",
+    "@opentelemetry/instrumentation": "^0.202.0",
+    "@opentelemetry/semantic-conventions": "^1.34.0",
     "@traceloop/ai-semantic-conventions": "^0.13.0",
     "tslib": "^2.8.1"
   },

--- a/packages/instrumentation-anthropic/test/instrumentation.test.ts
+++ b/packages/instrumentation-anthropic/test/instrumentation.test.ts
@@ -19,10 +19,10 @@ import * as assert from "assert";
 import { context } from "@opentelemetry/api";
 import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
 import {
-  BasicTracerProvider,
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 
 import * as AnthropicModule from "@anthropic-ai/sdk";
 
@@ -39,7 +39,7 @@ Polly.register(NodeHttpAdapter);
 Polly.register(FSPersister);
 
 describe("Test Anthropic instrumentation", async function () {
-  const provider = new BasicTracerProvider();
+  let provider: NodeTracerProvider;
   let instrumentation: AnthropicInstrumentation;
   let contextManager: AsyncHooksContextManager;
   let anthropic: AnthropicModule.Anthropic;
@@ -57,7 +57,9 @@ describe("Test Anthropic instrumentation", async function () {
     if (process.env.RECORD_MODE !== "NEW") {
       process.env.ANTHROPIC_API_KEY = "test-key";
     }
-    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+    });
     instrumentation = new AnthropicInstrumentation();
     instrumentation.setTracerProvider(provider);
 

--- a/packages/instrumentation-azure/package.json
+++ b/packages/instrumentation-azure/package.json
@@ -38,9 +38,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "^1.29.0",
-    "@opentelemetry/instrumentation": "^0.56.0",
-    "@opentelemetry/semantic-conventions": "^1.28.0",
+    "@opentelemetry/core": "^2.0.1",
+    "@opentelemetry/instrumentation": "^0.202.0",
+    "@opentelemetry/semantic-conventions": "^1.34.0",
     "@traceloop/ai-semantic-conventions": "^0.13.0",
     "tslib": "^2.8.1"
   },

--- a/packages/instrumentation-azure/test/instrumentation.test.ts
+++ b/packages/instrumentation-azure/test/instrumentation.test.ts
@@ -19,11 +19,10 @@ import * as assert from "assert";
 import { context } from "@opentelemetry/api";
 import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
 import {
-  BasicTracerProvider,
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
-
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { AzureKeyCredential } from "@azure/openai";
 import type * as AzureOpenAIModule from "@azure/openai";
 
@@ -40,7 +39,7 @@ Polly.register(NodeHttpAdapter);
 Polly.register(FSPersister);
 
 describe("Test OpenAI instrumentation", async function () {
-  const provider = new BasicTracerProvider();
+  let provider: NodeTracerProvider;
   let instrumentation: AzureOpenAIInstrumentation;
   let contextManager: AsyncHooksContextManager;
   let azureOpenAi: AzureOpenAIModule.OpenAIClient;
@@ -60,7 +59,9 @@ describe("Test OpenAI instrumentation", async function () {
       process.env.AZURE_API_KEY = "test-key";
       process.env.AZURE_DEPLOYMENT_ID = "openllmetry-testing";
     }
-    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+    });
     instrumentation = new AzureOpenAIInstrumentation();
     instrumentation.setTracerProvider(provider);
 

--- a/packages/instrumentation-bedrock/package.json
+++ b/packages/instrumentation-bedrock/package.json
@@ -38,9 +38,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "^1.29.0",
-    "@opentelemetry/instrumentation": "^0.56.0",
-    "@opentelemetry/semantic-conventions": "^1.28.0",
+    "@opentelemetry/core": "^2.0.1",
+    "@opentelemetry/instrumentation": "^0.202.0",
+    "@opentelemetry/semantic-conventions": "^1.34.0",
     "@traceloop/ai-semantic-conventions": "^0.13.0",
     "tslib": "^2.8.1"
   },

--- a/packages/instrumentation-bedrock/tests/ai21.test.ts
+++ b/packages/instrumentation-bedrock/tests/ai21.test.ts
@@ -19,7 +19,6 @@ import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
 import { BedrockInstrumentation } from "../src/instrumentation";
 import * as assert from "assert";
 import {
-  BasicTracerProvider,
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
@@ -29,6 +28,7 @@ import { SpanAttributes } from "@traceloop/ai-semantic-conventions";
 import { Polly, setupMocha as setupPolly } from "@pollyjs/core";
 import NodeHttpAdapter from "@pollyjs/adapter-node-http";
 import FSPersister from "@pollyjs/persister-fs";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 
 const memoryExporter = new InMemorySpanExporter();
 
@@ -36,7 +36,7 @@ Polly.register(NodeHttpAdapter);
 Polly.register(FSPersister);
 
 describe("Test Ai21 with AWS Bedrock Instrumentation", () => {
-  const provider = new BasicTracerProvider();
+  let provider: NodeTracerProvider;
   let instrumentation: BedrockInstrumentation;
   let contextManager: AsyncHooksContextManager;
   let bedrock: typeof bedrockModule;
@@ -50,7 +50,9 @@ describe("Test Ai21 with AWS Bedrock Instrumentation", () => {
   });
 
   before(async () => {
-    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+    });
     instrumentation = new BedrockInstrumentation();
     instrumentation.setTracerProvider(provider);
     bedrock = await import("@aws-sdk/client-bedrock-runtime");

--- a/packages/instrumentation-bedrock/tests/amazon.test.ts
+++ b/packages/instrumentation-bedrock/tests/amazon.test.ts
@@ -19,7 +19,6 @@ import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
 import { BedrockInstrumentation } from "../src/instrumentation";
 import * as assert from "assert";
 import {
-  BasicTracerProvider,
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
@@ -29,6 +28,7 @@ import { SpanAttributes } from "@traceloop/ai-semantic-conventions";
 import { Polly, setupMocha as setupPolly } from "@pollyjs/core";
 import NodeHttpAdapter from "@pollyjs/adapter-node-http";
 import FSPersister from "@pollyjs/persister-fs";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 
 const memoryExporter = new InMemorySpanExporter();
 
@@ -36,7 +36,7 @@ Polly.register(NodeHttpAdapter);
 Polly.register(FSPersister);
 
 describe("Test Amazon Titan with AWS Bedrock Instrumentation", () => {
-  const provider = new BasicTracerProvider();
+  let provider: NodeTracerProvider;
   let instrumentation: BedrockInstrumentation;
   let contextManager: AsyncHooksContextManager;
   let bedrock: typeof bedrockModule;
@@ -50,7 +50,9 @@ describe("Test Amazon Titan with AWS Bedrock Instrumentation", () => {
   });
 
   before(async () => {
-    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+    });
     instrumentation = new BedrockInstrumentation();
     instrumentation.setTracerProvider(provider);
     bedrock = await import("@aws-sdk/client-bedrock-runtime");

--- a/packages/instrumentation-bedrock/tests/anthropic.test.ts
+++ b/packages/instrumentation-bedrock/tests/anthropic.test.ts
@@ -19,7 +19,6 @@ import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
 import { BedrockInstrumentation } from "../src/instrumentation";
 import * as assert from "assert";
 import {
-  BasicTracerProvider,
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
@@ -29,6 +28,7 @@ import { SpanAttributes } from "@traceloop/ai-semantic-conventions";
 import { Polly, setupMocha as setupPolly } from "@pollyjs/core";
 import NodeHttpAdapter from "@pollyjs/adapter-node-http";
 import FSPersister from "@pollyjs/persister-fs";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 
 const memoryExporter = new InMemorySpanExporter();
 
@@ -36,7 +36,7 @@ Polly.register(NodeHttpAdapter);
 Polly.register(FSPersister);
 
 describe("Test Anthropic with AWS Bedrock Instrumentation", () => {
-  const provider = new BasicTracerProvider();
+  let provider: NodeTracerProvider;
   let instrumentation: BedrockInstrumentation;
   let contextManager: AsyncHooksContextManager;
   let bedrock: typeof bedrockModule;
@@ -50,7 +50,9 @@ describe("Test Anthropic with AWS Bedrock Instrumentation", () => {
   });
 
   before(async () => {
-    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+    });
     instrumentation = new BedrockInstrumentation();
     instrumentation.setTracerProvider(provider);
     bedrock = await import("@aws-sdk/client-bedrock-runtime");

--- a/packages/instrumentation-bedrock/tests/cohere.test.ts
+++ b/packages/instrumentation-bedrock/tests/cohere.test.ts
@@ -19,7 +19,6 @@ import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
 import { BedrockInstrumentation } from "../src/instrumentation";
 import * as assert from "assert";
 import {
-  BasicTracerProvider,
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
@@ -29,6 +28,7 @@ import { SpanAttributes } from "@traceloop/ai-semantic-conventions";
 import { Polly, setupMocha as setupPolly } from "@pollyjs/core";
 import NodeHttpAdapter from "@pollyjs/adapter-node-http";
 import FSPersister from "@pollyjs/persister-fs";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 
 const memoryExporter = new InMemorySpanExporter();
 
@@ -36,7 +36,7 @@ Polly.register(NodeHttpAdapter);
 Polly.register(FSPersister);
 
 describe("Test Cohere with AWS Bedrock Instrumentation", () => {
-  const provider = new BasicTracerProvider();
+  let provider: NodeTracerProvider;
   let instrumentation: BedrockInstrumentation;
   let contextManager: AsyncHooksContextManager;
   let bedrock: typeof bedrockModule;
@@ -50,7 +50,9 @@ describe("Test Cohere with AWS Bedrock Instrumentation", () => {
   });
 
   before(async () => {
-    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+    });
     instrumentation = new BedrockInstrumentation();
     instrumentation.setTracerProvider(provider);
     bedrock = await import("@aws-sdk/client-bedrock-runtime");

--- a/packages/instrumentation-chromadb/package.json
+++ b/packages/instrumentation-chromadb/package.json
@@ -38,9 +38,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "^1.29.0",
-    "@opentelemetry/instrumentation": "^0.56.0",
-    "@opentelemetry/semantic-conventions": "^1.28.0",
+    "@opentelemetry/core": "^2.0.1",
+    "@opentelemetry/instrumentation": "^0.202.0",
+    "@opentelemetry/semantic-conventions": "^1.34.0",
     "@traceloop/ai-semantic-conventions": "^0.13.0",
     "tslib": "^2.8.1"
   },

--- a/packages/instrumentation-cohere/package.json
+++ b/packages/instrumentation-cohere/package.json
@@ -38,9 +38,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "^1.29.0",
-    "@opentelemetry/instrumentation": "^0.56.0",
-    "@opentelemetry/semantic-conventions": "^1.28.0",
+    "@opentelemetry/core": "^2.0.1",
+    "@opentelemetry/instrumentation": "^0.202.0",
+    "@opentelemetry/semantic-conventions": "^1.34.0",
     "@traceloop/ai-semantic-conventions": "^0.13.0",
     "tslib": "^2.8.1"
   },

--- a/packages/instrumentation-cohere/tests/chat.test.ts
+++ b/packages/instrumentation-cohere/tests/chat.test.ts
@@ -19,7 +19,6 @@ import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
 import { CohereInstrumentation } from "../src/instrumentation";
 import * as assert from "assert";
 import {
-  BasicTracerProvider,
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
@@ -29,6 +28,7 @@ import { SpanAttributes } from "@traceloop/ai-semantic-conventions";
 import { Polly, setupMocha as setupPolly } from "@pollyjs/core";
 import FetchAdapter from "@pollyjs/adapter-fetch";
 import FSPersister from "@pollyjs/persister-fs";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 
 const memoryExporter = new InMemorySpanExporter();
 
@@ -36,7 +36,7 @@ Polly.register(FetchAdapter);
 Polly.register(FSPersister);
 
 describe.skip("Test Chat with Cohere Instrumentation", () => {
-  const provider = new BasicTracerProvider();
+  let provider: NodeTracerProvider;
   let instrumentation: CohereInstrumentation;
   let contextManager: AsyncHooksContextManager;
   let cohere: typeof cohereModule;
@@ -50,7 +50,9 @@ describe.skip("Test Chat with Cohere Instrumentation", () => {
   });
 
   before(async () => {
-    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+    });
     instrumentation = new CohereInstrumentation();
     instrumentation.setTracerProvider(provider);
     cohere = await import("cohere-ai");

--- a/packages/instrumentation-cohere/tests/generate.test.ts
+++ b/packages/instrumentation-cohere/tests/generate.test.ts
@@ -19,7 +19,6 @@ import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
 import { CohereInstrumentation } from "../src/instrumentation";
 import * as assert from "assert";
 import {
-  BasicTracerProvider,
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
@@ -29,6 +28,7 @@ import { SpanAttributes } from "@traceloop/ai-semantic-conventions";
 import { Polly, setupMocha as setupPolly } from "@pollyjs/core";
 import FetchAdapter from "@pollyjs/adapter-fetch";
 import FSPersister from "@pollyjs/persister-fs";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 
 const memoryExporter = new InMemorySpanExporter();
 
@@ -36,7 +36,7 @@ Polly.register(FetchAdapter);
 Polly.register(FSPersister);
 
 describe.skip("Test Generate with Cohere Instrumentation", () => {
-  const provider = new BasicTracerProvider();
+  let provider: NodeTracerProvider;
   let instrumentation: CohereInstrumentation;
   let contextManager: AsyncHooksContextManager;
   let cohere: typeof cohereModule;
@@ -50,7 +50,9 @@ describe.skip("Test Generate with Cohere Instrumentation", () => {
   });
 
   before(async () => {
-    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+    });
     instrumentation = new CohereInstrumentation();
     instrumentation.setTracerProvider(provider);
     cohere = await import("cohere-ai");

--- a/packages/instrumentation-cohere/tests/rerank.test.ts
+++ b/packages/instrumentation-cohere/tests/rerank.test.ts
@@ -19,7 +19,6 @@ import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
 import { CohereInstrumentation } from "../src/instrumentation";
 import * as assert from "assert";
 import {
-  BasicTracerProvider,
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
@@ -29,6 +28,7 @@ import { SpanAttributes } from "@traceloop/ai-semantic-conventions";
 import { Polly, setupMocha as setupPolly } from "@pollyjs/core";
 import FetchAdapter from "@pollyjs/adapter-fetch";
 import FSPersister from "@pollyjs/persister-fs";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 
 const memoryExporter = new InMemorySpanExporter();
 
@@ -36,7 +36,7 @@ Polly.register(FetchAdapter);
 Polly.register(FSPersister);
 
 describe.skip("Test Rerank with Cohere Instrumentation", () => {
-  const provider = new BasicTracerProvider();
+  let provider: NodeTracerProvider;
   let instrumentation: CohereInstrumentation;
   let contextManager: AsyncHooksContextManager;
   let cohere: typeof cohereModule;
@@ -50,7 +50,9 @@ describe.skip("Test Rerank with Cohere Instrumentation", () => {
   });
 
   before(async () => {
-    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+    });
     instrumentation = new CohereInstrumentation();
     instrumentation.setTracerProvider(provider);
     cohere = await import("cohere-ai");

--- a/packages/instrumentation-langchain/package.json
+++ b/packages/instrumentation-langchain/package.json
@@ -38,9 +38,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "^1.29.0",
-    "@opentelemetry/instrumentation": "^0.56.0",
-    "@opentelemetry/semantic-conventions": "^1.28.0",
+    "@opentelemetry/core": "^2.0.1",
+    "@opentelemetry/instrumentation": "^0.202.0",
+    "@opentelemetry/semantic-conventions": "^1.34.0",
     "@traceloop/ai-semantic-conventions": "^0.13.0",
     "tslib": "^2.8.1"
   },

--- a/packages/instrumentation-langchain/test/instrumentation.test.ts
+++ b/packages/instrumentation-langchain/test/instrumentation.test.ts
@@ -19,10 +19,10 @@ import * as assert from "assert";
 import { context } from "@opentelemetry/api";
 import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
 import {
-  BasicTracerProvider,
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 
 import type * as ToolsModule from "langchain/tools";
 import type * as AgentsModule from "langchain/agents";
@@ -49,7 +49,7 @@ Polly.register(NodeHttpAdapter);
 Polly.register(FSPersister);
 
 describe("Test Langchain instrumentation", async function () {
-  const provider = new BasicTracerProvider();
+  let provider: NodeTracerProvider;
   let instrumentation: LangChainInstrumentation;
   let contextManager: AsyncHooksContextManager;
   let langchainAgentsModule: typeof AgentsModule;
@@ -69,7 +69,9 @@ describe("Test Langchain instrumentation", async function () {
     if (process.env.RECORD_MODE !== "NEW") {
       process.env.OPENAI_API_KEY = "test";
     }
-    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+    });
     instrumentation = new LangChainInstrumentation();
     instrumentation.setTracerProvider(provider);
 

--- a/packages/instrumentation-llamaindex/package.json
+++ b/packages/instrumentation-llamaindex/package.json
@@ -37,9 +37,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "^1.29.0",
-    "@opentelemetry/instrumentation": "^0.56.0",
-    "@opentelemetry/semantic-conventions": "^1.28.0",
+    "@opentelemetry/core": "^2.0.1",
+    "@opentelemetry/instrumentation": "^0.202.0",
+    "@opentelemetry/semantic-conventions": "^1.34.0",
     "@traceloop/ai-semantic-conventions": "^0.13.0",
     "lodash": "^4.17.21",
     "tslib": "^2.8.1"

--- a/packages/instrumentation-openai/package.json
+++ b/packages/instrumentation-openai/package.json
@@ -37,9 +37,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "^1.29.0",
-    "@opentelemetry/instrumentation": "^0.56.0",
-    "@opentelemetry/semantic-conventions": "^1.28.0",
+    "@opentelemetry/core": "^2.0.1",
+    "@opentelemetry/instrumentation": "^0.202.0",
+    "@opentelemetry/semantic-conventions": "^1.34.0",
     "@traceloop/ai-semantic-conventions": "^0.13.0",
     "js-tiktoken": "^1.0.15",
     "tslib": "^2.8.1"

--- a/packages/instrumentation-openai/test/instrumentation.test.ts
+++ b/packages/instrumentation-openai/test/instrumentation.test.ts
@@ -19,10 +19,10 @@ import * as assert from "assert";
 import { context } from "@opentelemetry/api";
 import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
 import {
-  BasicTracerProvider,
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 
 import type * as OpenAIModule from "openai";
 
@@ -39,7 +39,7 @@ Polly.register(NodeHttpAdapter);
 Polly.register(FSPersister);
 
 describe("Test OpenAI instrumentation", async function () {
-  const provider = new BasicTracerProvider();
+  let provider: NodeTracerProvider;
   let instrumentation: OpenAIInstrumentation;
   let contextManager: AsyncHooksContextManager;
   let openai: OpenAIModule.OpenAI;
@@ -57,7 +57,9 @@ describe("Test OpenAI instrumentation", async function () {
     if (process.env.RECORD_MODE !== "NEW") {
       process.env.OPENAI_API_KEY = "test";
     }
-    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+    });
     instrumentation = new OpenAIInstrumentation({ enrichTokens: true });
     instrumentation.setTracerProvider(provider);
 

--- a/packages/instrumentation-pinecone/package.json
+++ b/packages/instrumentation-pinecone/package.json
@@ -38,9 +38,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "^1.29.0",
-    "@opentelemetry/instrumentation": "^0.56.0",
-    "@opentelemetry/semantic-conventions": "^1.28.0",
+    "@opentelemetry/core": "^2.0.1",
+    "@opentelemetry/instrumentation": "^0.202.0",
+    "@opentelemetry/semantic-conventions": "^1.34.0",
     "@traceloop/ai-semantic-conventions": "^0.13.0",
     "tslib": "^2.8.1"
   },

--- a/packages/instrumentation-pinecone/test/instrumentation.test.ts
+++ b/packages/instrumentation-pinecone/test/instrumentation.test.ts
@@ -20,7 +20,6 @@ import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
 import { PineconeInstrumentation } from "../src/instrumentation";
 import * as assert from "assert";
 import {
-  BasicTracerProvider,
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
@@ -28,6 +27,7 @@ import { Polly, setupMocha as setupPolly } from "@pollyjs/core";
 import FetchAdapter from "@pollyjs/adapter-fetch";
 import FSPersister from "@pollyjs/persister-fs";
 import { SpanAttributes } from "@traceloop/ai-semantic-conventions";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 
 const memoryExporter = new InMemorySpanExporter();
 
@@ -37,7 +37,7 @@ Polly.register(FetchAdapter);
 Polly.register(FSPersister);
 
 describe("Test Pinecone instrumentation", function () {
-  const provider = new BasicTracerProvider();
+  let provider: NodeTracerProvider;
   let pineconeModule: typeof pineconeModuleType;
   let instrumentation: PineconeInstrumentation;
   let contextManager: AsyncHooksContextManager;
@@ -57,7 +57,9 @@ describe("Test Pinecone instrumentation", function () {
     if (process.env.RECORD_MODE !== "NEW") {
       process.env.PINECONE_API_KEY = "test";
     }
-    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+    });
     instrumentation = new PineconeInstrumentation();
     instrumentation.setTracerProvider(provider);
 

--- a/packages/instrumentation-qdrant/package.json
+++ b/packages/instrumentation-qdrant/package.json
@@ -38,8 +38,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "^1.29.0",
-    "@opentelemetry/instrumentation": "^0.56.0",
+    "@opentelemetry/core": "^2.0.1",
+    "@opentelemetry/instrumentation": "^0.202.0",
     "@traceloop/ai-semantic-conventions": "^0.13.0",
     "tslib": "^2.8.1"
   },

--- a/packages/instrumentation-qdrant/tests/instrumentation.test.ts
+++ b/packages/instrumentation-qdrant/tests/instrumentation.test.ts
@@ -18,7 +18,6 @@ import { context } from "@opentelemetry/api";
 import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
 import { QdrantInstrumentation } from "../src/instrumentation";
 import {
-  BasicTracerProvider,
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
@@ -26,19 +25,22 @@ import type * as qdrant_types from "@qdrant/js-client-rest";
 import * as assert from "assert";
 import { SpanAttributes } from "@traceloop/ai-semantic-conventions";
 import { v4 as uuidv4 } from "uuid";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 
 const COLLECTION_NAME = uuidv4();
 
 const memoryExporter = new InMemorySpanExporter();
 
 describe("Test Qdrant instrumentation", function () {
-  const provider = new BasicTracerProvider();
+  let provider: NodeTracerProvider;
   let instrumentation: QdrantInstrumentation;
   let contextManager: AsyncHooksContextManager;
   let qdrantClient: qdrant_types.QdrantClient;
 
   before(async () => {
-    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+    });
     instrumentation = new QdrantInstrumentation({ traceContent: true });
     instrumentation.setTracerProvider(provider);
 

--- a/packages/instrumentation-together/package.json
+++ b/packages/instrumentation-together/package.json
@@ -37,9 +37,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "^1.29.0",
-    "@opentelemetry/instrumentation": "^0.56.0",
-    "@opentelemetry/semantic-conventions": "^1.28.0",
+    "@opentelemetry/core": "^2.0.1",
+    "@opentelemetry/instrumentation": "^0.202.0",
+    "@opentelemetry/semantic-conventions": "^1.34.0",
     "@traceloop/ai-semantic-conventions": "^0.13.0",
     "js-tiktoken": "^1.0.15",
     "tslib": "^2.8.1"

--- a/packages/instrumentation-together/test/instrumentation.test.ts
+++ b/packages/instrumentation-together/test/instrumentation.test.ts
@@ -19,10 +19,10 @@ import * as assert from "assert";
 import { context } from "@opentelemetry/api";
 import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
 import {
-  BasicTracerProvider,
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 
 import type * as TogetherAIModule from "together-ai";
 
@@ -39,7 +39,7 @@ Polly.register(NodeHttpAdapter);
 Polly.register(FSPersister);
 
 describe("Test Together instrumentation", async function () {
-  const provider = new BasicTracerProvider();
+  let provider: NodeTracerProvider;
   let instrumentation: TogetherInstrumentation;
   let contextManager: AsyncHooksContextManager;
   let together: TogetherAIModule.Together;
@@ -57,7 +57,9 @@ describe("Test Together instrumentation", async function () {
     if (process.env.RECORD_MODE !== "NEW") {
       process.env.TOGETHER_API_KEY = "test";
     }
-    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+    });
     instrumentation = new TogetherInstrumentation({ enrichTokens: true });
     instrumentation.setTracerProvider(provider);
 

--- a/packages/instrumentation-vertexai/package.json
+++ b/packages/instrumentation-vertexai/package.json
@@ -37,9 +37,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "^1.29.0",
-    "@opentelemetry/instrumentation": "^0.56.0",
-    "@opentelemetry/semantic-conventions": "^1.28.0",
+    "@opentelemetry/core": "^2.0.1",
+    "@opentelemetry/instrumentation": "^0.202.0",
+    "@opentelemetry/semantic-conventions": "^1.34.0",
     "@traceloop/ai-semantic-conventions": "^0.13.0",
     "tslib": "^2.8.1"
   },

--- a/packages/instrumentation-vertexai/tests/gemini.test.ts
+++ b/packages/instrumentation-vertexai/tests/gemini.test.ts
@@ -19,22 +19,24 @@ import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
 import { VertexAIInstrumentation } from "../src/vertexai-instrumentation";
 import * as assert from "assert";
 import {
-  BasicTracerProvider,
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
 import type * as vertexAiImport from "@google-cloud/vertexai";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 
 const memoryExporter = new InMemorySpanExporter();
 
 describe.skip("Test Gemini GenerativeModel Instrumentation", () => {
-  const provider = new BasicTracerProvider();
+  let provider: NodeTracerProvider;
   let instrumentation: VertexAIInstrumentation;
   let contextManager: AsyncHooksContextManager;
   let vertexAi: typeof vertexAiImport;
 
   before(() => {
-    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+    });
     instrumentation = new VertexAIInstrumentation();
     instrumentation.setTracerProvider(provider);
     vertexAi = require("@google-cloud/vertexai");

--- a/packages/instrumentation-vertexai/tests/palm2.test.ts
+++ b/packages/instrumentation-vertexai/tests/palm2.test.ts
@@ -19,23 +19,25 @@ import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
 import { AIPlatformInstrumentation } from "../src/aiplatform-instrumentation";
 import * as assert from "assert";
 import {
-  BasicTracerProvider,
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
 import type * as aiplatformImport from "@google-cloud/aiplatform";
 import { google } from "@google-cloud/aiplatform/build/protos/protos";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 
 const memoryExporter = new InMemorySpanExporter();
 
 describe.skip("Test PaLM2 PredictionServiceClient Instrumentation", () => {
-  const provider = new BasicTracerProvider();
+  let provider: NodeTracerProvider;
   let instrumentation: AIPlatformInstrumentation;
   let contextManager: AsyncHooksContextManager;
   let aiplatform: typeof aiplatformImport;
 
   before(() => {
-    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+    });
     instrumentation = new AIPlatformInstrumentation();
     instrumentation.setTracerProvider(provider);
     aiplatform = require("@google-cloud/aiplatform");

--- a/packages/sample-app/src/sample_otel_sdk.ts
+++ b/packages/sample-app/src/sample_otel_sdk.ts
@@ -1,9 +1,9 @@
 import { NodeSDK } from "@opentelemetry/sdk-node";
-import { Resource } from "@opentelemetry/resources";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 import * as traceloop from "@traceloop/node-server-sdk";
 import { trace } from "@opentelemetry/api";
 import OpenAI from "openai";
+import { resourceFromAttributes } from "@opentelemetry/resources";
 
 traceloop.initialize({
   tracingEnabled: false,
@@ -19,7 +19,7 @@ const traceloopSpanProcessor = traceloop.createSpanProcessor({
 
 // Initialize the OpenTelemetry SDK with Traceloop's span processor
 const sdk = new NodeSDK({
-  resource: new Resource({
+  resource: resourceFromAttributes({
     [ATTR_SERVICE_NAME]: "my-sample-app",
   }),
   spanProcessors: [traceloopSpanProcessor],

--- a/packages/traceloop-sdk/package.json
+++ b/packages/traceloop-sdk/package.json
@@ -35,8 +35,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/exporter-trace-otlp-proto": "^0.56.0",
-    "@opentelemetry/sdk-node": "^0.56.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "^0.202.0",
+    "@opentelemetry/sdk-node": "^0.202.0",
     "@traceloop/ai-semantic-conventions": "^0.13.0",
     "@traceloop/instrumentation-anthropic": "^0.13.0",
     "@traceloop/instrumentation-azure": "^0.13.0",

--- a/packages/traceloop-sdk/src/lib/tracing/index.ts
+++ b/packages/traceloop-sdk/src/lib/tracing/index.ts
@@ -1,9 +1,9 @@
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import { SpanProcessor } from "@opentelemetry/sdk-trace-node";
-import { baggageUtils } from "@opentelemetry/core";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+import { parseKeyPairsIntoRecord } from "@opentelemetry/core";
 import { context, diag } from "@opentelemetry/api";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
-import { Resource } from "@opentelemetry/resources";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 import { Instrumentation } from "@opentelemetry/instrumentation";
 import { InitializeOptions } from "../interfaces";
@@ -255,7 +255,7 @@ export const startTracing = (options: InitializeOptions) => {
   const headers =
     options.headers ||
     (process.env.TRACELOOP_HEADERS
-      ? baggageUtils.parseKeyPairsIntoRecord(process.env.TRACELOOP_HEADERS)
+      ? parseKeyPairsIntoRecord(process.env.TRACELOOP_HEADERS)
       : { Authorization: `Bearer ${options.apiKey}` });
 
   const traceExporter =
@@ -280,7 +280,7 @@ export const startTracing = (options: InitializeOptions) => {
   }
 
   _sdk = new NodeSDK({
-    resource: new Resource({
+    resource: resourceFromAttributes({
       [ATTR_SERVICE_NAME]: options.appName || process.env.npm_package_name,
     }),
     spanProcessors,

--- a/packages/traceloop-sdk/src/lib/tracing/span-processor.ts
+++ b/packages/traceloop-sdk/src/lib/tracing/span-processor.ts
@@ -4,7 +4,7 @@ import {
   SpanProcessor,
   ReadableSpan,
 } from "@opentelemetry/sdk-trace-node";
-import { baggageUtils } from "@opentelemetry/core";
+import { parseKeyPairsIntoRecord } from "@opentelemetry/core";
 import { Span, context } from "@opentelemetry/api";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
 import { SpanExporter } from "@opentelemetry/sdk-trace-base";
@@ -71,7 +71,7 @@ export const createSpanProcessor = (
   const headers =
     options.headers ||
     (process.env.TRACELOOP_HEADERS
-      ? baggageUtils.parseKeyPairsIntoRecord(process.env.TRACELOOP_HEADERS)
+      ? parseKeyPairsIntoRecord(process.env.TRACELOOP_HEADERS)
       : { Authorization: `Bearer ${options.apiKey}` });
 
   const traceExporter =
@@ -166,7 +166,7 @@ const onSpanEnd = (
   return (span: ReadableSpan): void => {
     if (
       instrumentationLibraries &&
-      !instrumentationLibraries.includes(span.instrumentationLibrary.name)
+      !instrumentationLibraries.includes(span.instrumentationScope.name)
     ) {
       return;
     }

--- a/packages/traceloop-sdk/test/decorators.test.ts
+++ b/packages/traceloop-sdk/test/decorators.test.ts
@@ -459,7 +459,7 @@ describe("Test SDK Decorators", () => {
       "joke_generator",
     );
     assert.strictEqual(
-      completionSpan.parentSpanId,
+      completionSpan.parentSpanContext?.spanId,
       workflowSpan.spanContext().spanId,
     );
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update OpenTelemetry dependencies to v2 and adjust test setups across multiple packages.
> 
>   - **Dependencies**:
>     - Update `@opentelemetry/core` to `^2.0.1` in `package.json` files for multiple packages.
>     - Update `@opentelemetry/instrumentation` to `^0.202.0` in `package.json` files for multiple packages.
>     - Update `@opentelemetry/semantic-conventions` to `^1.34.0` in `package.json` files for multiple packages.
>   - **Test Setup**:
>     - Replace `BasicTracerProvider` with `NodeTracerProvider` in test files such as `instrumentation.test.ts` for packages like `instrumentation-anthropic`, `instrumentation-azure`, and others.
>     - Modify test setup to use `NodeTracerProvider` with `spanProcessors` in `before` hooks.
>   - **Miscellaneous**:
>     - Update `resource` initialization to use `resourceFromAttributes` in `sample_otel_sdk.ts` and `index.ts`.
>     - Replace `baggageUtils.parseKeyPairsIntoRecord` with `parseKeyPairsIntoRecord` in `index.ts` and `span-processor.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry-js&utm_source=github&utm_medium=referral)<sup> for 70e2e1844bdbe9badabf5c4a290340742c5f1af0. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->