### PR TITLE
fix(ci): add pnpm lock step when creating new version

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "license": "Apache-2.0",
   "scripts": {
     "build:all": "pnpm nx run-many -t build",
-    "build:affected": "pnpm nx affected -t build"
+    "build:affected": "pnpm nx affected -t build",
+    "version": "pnpm install --lockfile-only && git add pnpm-lock.yaml"
   },
   "private": true,
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -623,7 +623,7 @@ importers:
         version: 0.14.0
       google-gax:
         specifier: ^4.0.0
-        version: 4.6.1(encoding@0.1.13)
+        version: 4.6.1(encoding@0.1.13)(supports-color@10.0.0)
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -758,38 +758,38 @@ importers:
         specifier: ^0.14.0
         version: 0.14.0
       '@traceloop/instrumentation-anthropic':
-        specifier: ^0.14.4
-        version: 0.14.4(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
+        specifier: ^0.14.5
+        version: 0.14.5(supports-color@10.0.0)
       '@traceloop/instrumentation-bedrock':
-        specifier: ^0.14.4
-        version: 0.14.4(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
+        specifier: ^0.14.5
+        version: 0.14.5(supports-color@10.0.0)
       '@traceloop/instrumentation-chromadb':
-        specifier: ^0.14.4
-        version: 0.14.4(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
+        specifier: ^0.14.5
+        version: 0.14.5(supports-color@10.0.0)
       '@traceloop/instrumentation-cohere':
-        specifier: ^0.14.4
-        version: 0.14.4(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
+        specifier: ^0.14.5
+        version: 0.14.5(supports-color@10.0.0)
       '@traceloop/instrumentation-langchain':
-        specifier: ^0.14.4
-        version: 0.14.4(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
+        specifier: ^0.14.5
+        version: 0.14.5(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(openai@4.38.3(encoding@0.1.13))(supports-color@10.0.0)
       '@traceloop/instrumentation-llamaindex':
-        specifier: ^0.14.4
-        version: 0.14.4(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
+        specifier: ^0.14.5
+        version: 0.14.5(supports-color@10.0.0)
       '@traceloop/instrumentation-openai':
-        specifier: ^0.14.4
-        version: 0.14.4(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
+        specifier: ^0.14.5
+        version: 0.14.5(supports-color@10.0.0)
       '@traceloop/instrumentation-pinecone':
-        specifier: ^0.14.4
-        version: 0.14.4(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
+        specifier: ^0.14.5
+        version: 0.14.5(supports-color@10.0.0)
       '@traceloop/instrumentation-qdrant':
-        specifier: ^0.14.4
-        version: 0.14.4(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
+        specifier: ^0.14.5
+        version: 0.14.5(supports-color@10.0.0)
       '@traceloop/instrumentation-together':
-        specifier: ^0.14.4
-        version: 0.14.4(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
+        specifier: ^0.14.5
+        version: 0.14.5(supports-color@10.0.0)
       '@traceloop/instrumentation-vertexai':
-        specifier: ^0.14.4
-        version: 0.14.4(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
+        specifier: ^0.14.5
+        version: 0.14.5(encoding@0.1.13)(supports-color@10.0.0)
       '@types/nunjucks':
         specifier: ^3.2.6
         version: 3.2.6
@@ -3613,44 +3613,88 @@ packages:
     resolution: {integrity: sha512-aorD6MIy1SW1gX8FYj+m4XgXWyRAj7ECIfA3K1cH8p5fQsNREaKOfTrS0iQkq3oAYxTAGFu3FZZbtpqLZd+SBA==}
     engines: {node: '>=14'}
 
+  '@traceloop/instrumentation-anthropic@0.14.5':
+    resolution: {integrity: sha512-fC1ZxRjQ3JNWIoxJrMKgln9aEWxeyQXdcB2bsQx8Z6N/IVtKeZd8TblNX1wKEsGlKTbBgo3m83Ukdi67XnCkag==}
+    engines: {node: '>=14'}
+
   '@traceloop/instrumentation-bedrock@0.14.4':
     resolution: {integrity: sha512-ZDvGkNmr2td/OWWUqSHZRf6RkYKSu5FXehkQqQkP6RliKbTNCGHzZFEVnZrlAb4e150EXFoTsISadfomfgzyRA==}
+    engines: {node: '>=14'}
+
+  '@traceloop/instrumentation-bedrock@0.14.5':
+    resolution: {integrity: sha512-Z41ZJ9eihvV6FqF0EC+u408TAkgGJPONHbw3iWa/UXm+CjbLPGX6FPQD8l82arnrlysCmrfFKmYmdxE43mNCKw==}
     engines: {node: '>=14'}
 
   '@traceloop/instrumentation-chromadb@0.14.4':
     resolution: {integrity: sha512-CsMIAOTwUjTyEoa7N1jVDelCMl++yLp9xm0ag32xPGzoBnQW5xWOnj4ObzYIP2h8YIoupUw1F8hfa50muLMjBA==}
     engines: {node: '>=14'}
 
+  '@traceloop/instrumentation-chromadb@0.14.5':
+    resolution: {integrity: sha512-sIga1Mc1h4l6jLS6ne7za0zm2UT26REXbjJfcstBzszWcq72j2uKBiYzZLcrpntA0AbVsKZsFqTDufD1anmmZg==}
+    engines: {node: '>=14'}
+
   '@traceloop/instrumentation-cohere@0.14.4':
     resolution: {integrity: sha512-b4PxpaICrbtyhrKmfv85MZ0VQE1HZHOpmFBFZQtw9epVcc889y6DcMC0KHRuSxVCISQM4CHhBWbwLgl0W3D0Ow==}
+    engines: {node: '>=14'}
+
+  '@traceloop/instrumentation-cohere@0.14.5':
+    resolution: {integrity: sha512-Qac0aiHnYtvbUVK3ksFioTlQgOXnXKJKDIk8DaZ1bvOiyFoVzO7BH8RxISRxf9d3nn0d7jGf1KI8sN0m25T74Q==}
     engines: {node: '>=14'}
 
   '@traceloop/instrumentation-langchain@0.14.4':
     resolution: {integrity: sha512-lGQ28XjsTl2hLNriVNAC3+zZpDZEcWmqWYHKglGzqTSEPH7aKaH08cCpsALqo1jJQaGlAMylZX18JYLkSeWvpA==}
     engines: {node: '>=14'}
 
+  '@traceloop/instrumentation-langchain@0.14.5':
+    resolution: {integrity: sha512-nwxZteikK/cx+CjwYSZigB2oFgEV7EjXO8Y9TCZnGZHjQCvkGBxyzT8ckWb/N9rKazyB7M5BzxleSSO9H8p/sQ==}
+    engines: {node: '>=14'}
+
   '@traceloop/instrumentation-llamaindex@0.14.4':
     resolution: {integrity: sha512-vCCC+Ke98XjErq+qe4ssXV8Y3hK895vlFUZTUL5yHgSt5y40ig3eSgtcZdIFLfJ2H0kyTY1Z8wkcegefr/UBgA==}
+    engines: {node: '>=14'}
+
+  '@traceloop/instrumentation-llamaindex@0.14.5':
+    resolution: {integrity: sha512-iBs7bn2tSP2dGNaOMl3Hn4AMRVHRxi3NfYrh1F/QfCRdZMXZZtwbAM6wTi+E+mDXICf4myd/p7reqQEAnfMPfw==}
     engines: {node: '>=14'}
 
   '@traceloop/instrumentation-openai@0.14.4':
     resolution: {integrity: sha512-Jv98P3p2u0dz9c10zN+FRA0XENYNCAmMPXehT4aDeGl6p0x92QTD6KOR6fPDTDxepCrq0dy2UKlJJKk2Mmgj5Q==}
     engines: {node: '>=14'}
 
+  '@traceloop/instrumentation-openai@0.14.5':
+    resolution: {integrity: sha512-fg/EpNos8k3F6KgHqobPJLZ8n1bM8UybUGLe9zXIvG7RoqcBMZjG0TT+T/qqjnEuBcgRZkDMVc+BE9EFNFCb3w==}
+    engines: {node: '>=14'}
+
   '@traceloop/instrumentation-pinecone@0.14.4':
     resolution: {integrity: sha512-bNBET/Ta3aD2Jlfus2QpX0/yQ9LZWTpqM7KHNmcyDfmUwk3xc3dReY5UYGklrwuFeNc5JJiUzxKnuBpLaLc4uw==}
+    engines: {node: '>=14'}
+
+  '@traceloop/instrumentation-pinecone@0.14.5':
+    resolution: {integrity: sha512-nSC9sX7Hys9sQEwuV3Pd/8g7cG/1N7+M+R3BXIj9MKLxC4Ke3WssmNJSua0CFJZ4BJsPA3Ah9+cfickgJI39Hg==}
     engines: {node: '>=14'}
 
   '@traceloop/instrumentation-qdrant@0.14.4':
     resolution: {integrity: sha512-4Z1TjlFCJLB5x41LJePOekV/1OUsqXSwROo/oJCnM/w/dh36E9qbdlvsu9IIYXsNqCN7WFHsle9zIdk2tZ8t0g==}
     engines: {node: '>=14'}
 
+  '@traceloop/instrumentation-qdrant@0.14.5':
+    resolution: {integrity: sha512-BNOFPtn8uDERL2adSYzliLGxAzbazSYbpmyRguZr7Pk/zHcXXfYvwpGlK5nx2aVqlHa2WRXoLMJjjV3PWunLPw==}
+    engines: {node: '>=14'}
+
   '@traceloop/instrumentation-together@0.14.4':
     resolution: {integrity: sha512-4OFQOEroJzjAFGn9Iejab9MHgkfXvlgbu0sSuKkF12BXvK5/djGqzdKJKTe2W6+kx87Pqf1qVrV+V2TF3c+JBw==}
     engines: {node: '>=14'}
 
+  '@traceloop/instrumentation-together@0.14.5':
+    resolution: {integrity: sha512-PL4CUwjJX6tGnuq5KuK9nCEkU5o0KcYKI/PAdrnurr1BRijZdvW0ebuJzunaLtvlyntc1aRxVfB3MVSbakrQvg==}
+    engines: {node: '>=14'}
+
   '@traceloop/instrumentation-vertexai@0.14.4':
     resolution: {integrity: sha512-hYaiU3JKQ8ebM/CN/eAKBww8pvHTEdWJt890YSm272YpoikNF00tV+FplSM68/Bb4wW5aENTX9P5XaOESKGXvw==}
+    engines: {node: '>=14'}
+
+  '@traceloop/instrumentation-vertexai@0.14.5':
+    resolution: {integrity: sha512-m4d4/veqfZl0CmULzqXvGXTm3L/5ijZJBKVVz62qVMJX9IKCVvYu9KWj94VzT0zRZtzHzhNhIrcDLp7zBvflxA==}
     engines: {node: '>=14'}
 
   '@traceloop/node-server-sdk@0.14.4':
@@ -11555,6 +11599,17 @@ snapshots:
       - '@opentelemetry/api'
       - supports-color
 
+  '@traceloop/instrumentation-anthropic@0.14.5(supports-color@10.0.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
+      '@opentelemetry/semantic-conventions': 1.36.0
+      '@traceloop/ai-semantic-conventions': 0.14.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@traceloop/instrumentation-bedrock@0.14.4(@opentelemetry/api@1.9.0)(supports-color@10.0.0)':
     dependencies:
       '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
@@ -11564,6 +11619,17 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@opentelemetry/api'
+      - supports-color
+
+  '@traceloop/instrumentation-bedrock@0.14.5(supports-color@10.0.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
+      '@opentelemetry/semantic-conventions': 1.36.0
+      '@traceloop/ai-semantic-conventions': 0.14.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
       - supports-color
 
   '@traceloop/instrumentation-chromadb@0.14.4(@opentelemetry/api@1.9.0)(supports-color@10.0.0)':
@@ -11577,6 +11643,17 @@ snapshots:
       - '@opentelemetry/api'
       - supports-color
 
+  '@traceloop/instrumentation-chromadb@0.14.5(supports-color@10.0.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
+      '@opentelemetry/semantic-conventions': 1.36.0
+      '@traceloop/ai-semantic-conventions': 0.14.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@traceloop/instrumentation-cohere@0.14.4(@opentelemetry/api@1.9.0)(supports-color@10.0.0)':
     dependencies:
       '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
@@ -11588,6 +11665,17 @@ snapshots:
       - '@opentelemetry/api'
       - supports-color
 
+  '@traceloop/instrumentation-cohere@0.14.5(supports-color@10.0.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
+      '@opentelemetry/semantic-conventions': 1.36.0
+      '@traceloop/ai-semantic-conventions': 0.14.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@traceloop/instrumentation-langchain@0.14.4(@opentelemetry/api@1.9.0)(supports-color@10.0.0)':
     dependencies:
       '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
@@ -11597,6 +11685,21 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@opentelemetry/api'
+      - supports-color
+
+  '@traceloop/instrumentation-langchain@0.14.5(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(openai@4.38.3(encoding@0.1.13))(supports-color@10.0.0)':
+    dependencies:
+      '@langchain/core': 0.3.66(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(openai@4.38.3(encoding@0.1.13))
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
+      '@opentelemetry/semantic-conventions': 1.36.0
+      '@traceloop/ai-semantic-conventions': 0.14.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
       - supports-color
 
   '@traceloop/instrumentation-llamaindex@0.14.4(@opentelemetry/api@1.9.0)(supports-color@10.0.0)':
@@ -11611,6 +11714,18 @@ snapshots:
       - '@opentelemetry/api'
       - supports-color
 
+  '@traceloop/instrumentation-llamaindex@0.14.5(supports-color@10.0.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
+      '@opentelemetry/semantic-conventions': 1.36.0
+      '@traceloop/ai-semantic-conventions': 0.14.0
+      lodash: 4.17.21
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@traceloop/instrumentation-openai@0.14.4(@opentelemetry/api@1.9.0)(supports-color@10.0.0)':
     dependencies:
       '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
@@ -11621,6 +11736,18 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@opentelemetry/api'
+      - supports-color
+
+  '@traceloop/instrumentation-openai@0.14.5(supports-color@10.0.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
+      '@opentelemetry/semantic-conventions': 1.36.0
+      '@traceloop/ai-semantic-conventions': 0.14.0
+      js-tiktoken: 1.0.20
+      tslib: 2.8.1
+    transitivePeerDependencies:
       - supports-color
 
   '@traceloop/instrumentation-pinecone@0.14.4(@opentelemetry/api@1.9.0)(supports-color@10.0.0)':
@@ -11634,6 +11761,17 @@ snapshots:
       - '@opentelemetry/api'
       - supports-color
 
+  '@traceloop/instrumentation-pinecone@0.14.5(supports-color@10.0.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
+      '@opentelemetry/semantic-conventions': 1.36.0
+      '@traceloop/ai-semantic-conventions': 0.14.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@traceloop/instrumentation-qdrant@0.14.4(@opentelemetry/api@1.9.0)(supports-color@10.0.0)':
     dependencies:
       '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
@@ -11642,6 +11780,16 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@opentelemetry/api'
+      - supports-color
+
+  '@traceloop/instrumentation-qdrant@0.14.5(supports-color@10.0.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
+      '@traceloop/ai-semantic-conventions': 0.14.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
       - supports-color
 
   '@traceloop/instrumentation-together@0.14.4(@opentelemetry/api@1.9.0)(supports-color@10.0.0)':
@@ -11656,6 +11804,18 @@ snapshots:
       - '@opentelemetry/api'
       - supports-color
 
+  '@traceloop/instrumentation-together@0.14.5(supports-color@10.0.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
+      '@opentelemetry/semantic-conventions': 1.36.0
+      '@traceloop/ai-semantic-conventions': 0.14.0
+      js-tiktoken: 1.0.20
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@traceloop/instrumentation-vertexai@0.14.4(@opentelemetry/api@1.9.0)(supports-color@10.0.0)':
     dependencies:
       '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
@@ -11665,6 +11825,19 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@opentelemetry/api'
+      - supports-color
+
+  '@traceloop/instrumentation-vertexai@0.14.5(encoding@0.1.13)(supports-color@10.0.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
+      '@opentelemetry/semantic-conventions': 1.36.0
+      '@traceloop/ai-semantic-conventions': 0.14.0
+      google-gax: 4.6.1(encoding@0.1.13)(supports-color@10.0.0)
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - encoding
       - supports-color
 
   '@traceloop/node-server-sdk@0.14.4(@opentelemetry/api@1.9.0)(encoding@0.1.13)':
@@ -13527,7 +13700,7 @@ snapshots:
       - encoding
       - supports-color
 
-  google-gax@4.6.1(encoding@0.1.13):
+  google-gax@4.6.1(encoding@0.1.13)(supports-color@10.0.0):
     dependencies:
       '@grpc/grpc-js': 1.13.4
       '@grpc/proto-loader': 0.7.15
@@ -13539,7 +13712,7 @@ snapshots:
       object-hash: 3.0.0
       proto3-json-serializer: 2.0.2
       protobufjs: 7.5.3
-      retry-request: 7.0.2(encoding@0.1.13)
+      retry-request: 7.0.2(encoding@0.1.13)(supports-color@10.0.0)
       uuid: 9.0.1
     transitivePeerDependencies:
       - encoding
@@ -15612,11 +15785,11 @@ snapshots:
     dependencies:
       axios: 1.10.0(debug@4.4.1)
 
-  retry-request@7.0.2(encoding@0.1.13):
+  retry-request@7.0.2(encoding@0.1.13)(supports-color@10.0.0):
     dependencies:
       '@types/request': 2.48.12
       extend: 3.0.2
-      teeny-request: 9.0.0(encoding@0.1.13)
+      teeny-request: 9.0.0(encoding@0.1.13)(supports-color@10.0.0)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -15978,7 +16151,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  teeny-request@9.0.0(encoding@0.1.13):
+  teeny-request@9.0.0(encoding@0.1.13)(supports-color@10.0.0):
     dependencies:
       http-proxy-agent: 5.0.0(supports-color@10.0.0)
       https-proxy-agent: 5.0.1(supports-color@10.0.0)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `version` script to update and stage `pnpm-lock.yaml` in `package.json`.
> 
>   - **Scripts**:
>     - Adds `version` script in `package.json` to run `pnpm install --lockfile-only` and stage `pnpm-lock.yaml` with `git add`.
>   - **Purpose**:
>     - Ensures `pnpm-lock.yaml` is updated and committed when creating a new version.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry-js&utm_source=github&utm_medium=referral)<sup> for 857f15170189ea13e554c7dddb83a1f00ae23425. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new script to streamline updating and staging the lockfile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->