### PR TITLE
chore(ci): fix lerna release for otel v1

### DIFF
--- a/.github/workflows/release-otel-v1.yml
+++ b/.github/workflows/release-otel-v1.yml
@@ -50,4 +50,4 @@ jobs:
       - name: Publish with otel-v1 tag
         run: |
           # Publish all packages with otel-v1 dist-tag
-          pnpm lerna publish from-git --dist-tag otel-v1 --no-private --yes
+          pnpm lerna publish from-package --dist-tag otel-v1 --no-private --yes


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `lerna publish` command in CI workflow to use `from-package` instead of `from-git`.
> 
>   - **CI Workflow**:
>     - In `.github/workflows/release-otel-v1.yml`, change `lerna publish` command from `from-git` to `from-package` to publish packages with `otel-v1` dist-tag.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry-js&utm_source=github&utm_medium=referral)<sup> for c3009c6cc2a5b20983b221af6cb38794a841bf29. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated the release process for the otel-v1 channel to determine package versions from package manifests rather than git tags, keeping existing distribution tags and publish options unchanged.
  * Improves consistency of published versions and reduces dependency on repository tagging.
  * No functional or UI changes; end users may only notice adjusted version numbering in newly published packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->