### PR TITLE
chore(ci): commit versions for lerna publish of otel v1

### DIFF
--- a/.github/workflows/release-otel-v1.yml
+++ b/.github/workflows/release-otel-v1.yml
@@ -38,8 +38,10 @@ jobs:
           CURRENT_VERSION=$(node -p 'require("./lerna.json").version')
           NEW_VERSION="${CURRENT_VERSION}-otel-v1"
           echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
-          # Update versions in memory only (no git commits)
-          pnpm lerna version $NEW_VERSION --no-private --no-git-tag-version --no-push --yes
+          # Update versions and commit changes
+          pnpm lerna version $NEW_VERSION --no-private --no-push --yes
+          git add .
+          git commit -m "chore: version bump to ${NEW_VERSION} for otel-v1 release"
       - name: "NPM Identity"
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -50,4 +52,4 @@ jobs:
       - name: Publish with otel-v1 tag
         run: |
           # Publish all packages with otel-v1 dist-tag
-          pnpm lerna publish from-package --dist-tag otel-v1 --no-private --yes
+          pnpm lerna publish from-git --dist-tag otel-v1 --no-private --yes


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify release workflow to commit version changes and publish from git for OpenTelemetry v1.
> 
>   - **Workflow Changes**:
>     - In `.github/workflows/release-otel-v1.yml`, change `lerna publish` command from `from-package` to `from-git` to publish packages.
>     - Add git commit step after version bump to commit version changes with message `"chore: version bump to ${NEW_VERSION} for otel-v1 release"`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry-js&utm_source=github&utm_medium=referral)<sup> for 2f635de9c6f4a968fd9cfda23dbabb0446c703ee. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Chores
  - Release workflow now commits version updates instead of keeping them in memory.
  - Publishing step now sources releases from git state using the otel-v1 tag.
  - Updated inline comment in the workflow to reflect the new versioning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->