### PR TITLE
fix(sdk): export getTraceloopTracer for direct tracer access

### DIFF
--- a/packages/traceloop-sdk/src/lib/node-server-sdk.ts
+++ b/packages/traceloop-sdk/src/lib/node-server-sdk.ts
@@ -34,6 +34,7 @@ export { Experiment } from "./client/experiment";
 export { Evaluator } from "./client/evaluator";
 export { initialize, getClient } from "./configuration";
 export { forceFlush } from "./tracing";
+export { getTraceloopTracer } from "./tracing/tracing";
 export * from "./tracing/decorators";
 export * from "./tracing/manual";
 export * from "./tracing/association";

--- a/packages/traceloop-sdk/src/lib/tracing/tracing.ts
+++ b/packages/traceloop-sdk/src/lib/tracing/tracing.ts
@@ -12,6 +12,8 @@ export const getTracer = () => {
   return trace.getTracer(TRACER_NAME);
 };
 
+export const getTraceloopTracer = getTracer;
+
 export const getEntityPath = (entityContext: Context): string | undefined => {
   const path = entityContext.getValue(ENTITY_NAME_KEY);
 


### PR DESCRIPTION
## Summary
- Exports `getTraceloopTracer` function from the main SDK
- Allows users to access the OpenTelemetry tracer instance for custom span creation
- Maintains backward compatibility with existing internal `getTracer` function

## Test plan
- [ ] Verify the function is properly exported from the main SDK package
- [ ] Test that users can import and use `getTraceloopTracer` 
- [ ] Ensure existing functionality remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Exports `getTraceloopTracer` from SDK for direct OpenTelemetry tracer access, maintaining backward compatibility.
> 
>   - **Functionality**:
>     - Exports `getTraceloopTracer` from `node-server-sdk.ts` for direct access to OpenTelemetry tracer.
>     - `getTraceloopTracer` is an alias for existing `getTracer` in `tracing.ts`.
>   - **Compatibility**:
>     - Maintains backward compatibility with existing `getTracer` function.
>   - **Testing**:
>     - Verify export and usability of `getTraceloopTracer`.
>     - Ensure no changes to existing functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry-js&utm_source=github&utm_medium=referral)<sup> for fd1c43dc3bb1e2e006aa5f5352ee6ed00b2ac17f. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduced a new public API alias to retrieve the tracer, expanding the SDK’s surface for easier integration and clearer naming.
  * Existing APIs remain unchanged and fully compatible; this is an additive, opt-in capability with no behavioral changes.
  * Developers can use either naming convention without migration.
  * Current documentation and examples continue to work, with the new alias available for new code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->