### PR TITLE
fix(instrumentation-vertexai): re-enable Gemini tests with Polly.js mocking (closes #58)

### DIFF
--- a/packages/instrumentation-vertexai/package.json
+++ b/packages/instrumentation-vertexai/package.json
@@ -50,7 +50,12 @@
     "@google-cloud/vertexai": "^1.10.0",
     "@opentelemetry/context-async-hooks": "^2.0.1",
     "@opentelemetry/sdk-trace-base": "^2.0.1",
+    "@opentelemetry/sdk-trace-node": "^2.0.1",
+    "@pollyjs/adapter-fetch": "^6.0.7",
+    "@pollyjs/adapter-node-http": "^6.0.6",
+    "@pollyjs/core": "^6.0.6",
     "@types/mocha": "^10.0.10",
+    "google-auth-library": "^9.0.0",
     "ts-mocha": "^11.1.0"
   },
   "homepage": "https://github.com/traceloop/openllmetry-js/tree/main/packages/instrumentation-openai",

--- a/packages/instrumentation-vertexai/recordings/Test-Gemini-GenerativeModel-Instrumentation_3759181793/should-set-request-and-response-attributes-in-span-for-Text-prompts-with-non-stream-respo_3734255465/recording.har
+++ b/packages/instrumentation-vertexai/recordings/Test-Gemini-GenerativeModel-Instrumentation_3759181793/should-set-request-and-response-attributes-in-span-for-Text-prompts-with-non-stream-respo_3734255465/recording.har
@@ -1,0 +1,70 @@
+{
+  "log": {
+    "_recordingName": "Test Gemini GenerativeModel Instrumentation/should set request and response attributes in span for Text prompts with non-stream response",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 120,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ],
+          "headersSize": 40,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"contents\":[{\"role\":\"user\",\"parts\":[{\"text\":\"What is Node.js?\"}]}],\"generationConfig\":{\"topP\":0.9,\"maxOutputTokens\":256}}"
+          },
+          "queryString": [],
+          "url": "https://us-central1-aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/publishers/google/models/gemini-pro-vision:generateContent"
+        },
+        "response": {
+          "bodySize": 280,
+          "content": {
+            "mimeType": "application/json",
+            "size": 280,
+            "text": "{\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine.\"}],\"role\":\"model\"},\"finishReason\":\"STOP\",\"index\":0}],\"usageMetadata\":{\"promptTokenCount\":6,\"candidatesTokenCount\":14,\"totalTokenCount\":20}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json; charset=UTF-8"
+            }
+          ],
+          "headersSize": 50,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-01T00:00:00.000Z",
+        "time": 100,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 100
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/packages/instrumentation-vertexai/recordings/Test-Gemini-GenerativeModel-Instrumentation_3759181793/should-set-request-and-response-attributes-in-span-for-Text-prompts-with-streaming-respon_1664253223/recording.har
+++ b/packages/instrumentation-vertexai/recordings/Test-Gemini-GenerativeModel-Instrumentation_3759181793/should-set-request-and-response-attributes-in-span-for-Text-prompts-with-streaming-respon_1664253223/recording.har
@@ -1,0 +1,75 @@
+{
+  "log": {
+    "_recordingName": "Test Gemini GenerativeModel Instrumentation/should set request and response attributes in span for Text prompts with streaming response",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 130,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ],
+          "headersSize": 40,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"contents\":[{\"role\":\"user\",\"parts\":[{\"text\":\"What are the 4 cardinal directions?\"}]}],\"generationConfig\":{\"topP\":0.9,\"maxOutputTokens\":256}}"
+          },
+          "queryString": [
+            {
+              "name": "alt",
+              "value": "sse"
+            }
+          ],
+          "url": "https://us-central1-aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/publishers/google/models/gemini-pro-vision:streamGenerateContent?alt=sse"
+        },
+        "response": {
+          "bodySize": 300,
+          "content": {
+            "mimeType": "text/event-stream",
+            "size": 300,
+            "text": "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"The four cardinal directions are North, South, East, and West.\"}],\"role\":\"model\"},\"finishReason\":\"STOP\",\"index\":0}],\"usageMetadata\":{\"promptTokenCount\":9,\"candidatesTokenCount\":13,\"totalTokenCount\":22}}\n\n"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "text/event-stream"
+            }
+          ],
+          "headersSize": 40,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-01T00:00:00.000Z",
+        "time": 100,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 100
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/packages/instrumentation-vertexai/src/vertexai-instrumentation.ts
+++ b/packages/instrumentation-vertexai/src/vertexai-instrumentation.ts
@@ -159,13 +159,13 @@ export class VertexAIInstrumentation extends InstrumentationBase {
 
       if (instance["generationConfig"]) {
         attributes[ATTR_GEN_AI_REQUEST_MAX_TOKENS] =
-          instance["generationConfig"].max_output_tokens;
+          instance["generationConfig"].maxOutputTokens;
         attributes[ATTR_GEN_AI_REQUEST_TEMPERATURE] =
           instance["generationConfig"].temperature;
         attributes[ATTR_GEN_AI_REQUEST_TOP_P] =
-          instance["generationConfig"].top_p;
+          instance["generationConfig"].topP;
         attributes[SpanAttributes.LLM_TOP_K] =
-          instance["generationConfig"].top_k;
+          instance["generationConfig"].topK;
       }
 
       if (this._shouldSendPrompts() && "contents" in params) {

--- a/packages/instrumentation-vertexai/tests/gemini.test.ts
+++ b/packages/instrumentation-vertexai/tests/gemini.test.ts
@@ -114,7 +114,6 @@ describe("Test Gemini GenerativeModel Instrumentation", () => {
     instrumentation.setTracerProvider(provider);
     instrumentation.enable();
     vertexAi = require("@google-cloud/vertexai");
-    instrumentation.manuallyInstrument(vertexAi);
   });
 
   after(() => {

--- a/packages/instrumentation-vertexai/tests/gemini.test.ts
+++ b/packages/instrumentation-vertexai/tests/gemini.test.ts
@@ -92,6 +92,8 @@ describe("Test Gemini GenerativeModel Instrumentation", () => {
   let contextManager: AsyncHooksContextManager;
   let vertexAi: typeof vertexAiImport;
   let originalGetAccessToken: typeof GoogleAuth.prototype.getAccessToken;
+  let origProjectId: string | undefined;
+  let origLocation: string | undefined;
 
   setupPolly({
     adapters: ["node-http", "fetch"],
@@ -99,6 +101,8 @@ describe("Test Gemini GenerativeModel Instrumentation", () => {
   });
 
   before(async () => {
+    origProjectId = process.env.VERTEXAI_PROJECT_ID;
+    origLocation = process.env.VERTEXAI_LOCATION;
     process.env.VERTEXAI_PROJECT_ID = "test-project";
     process.env.VERTEXAI_LOCATION = "us-central1";
     // Stub Google Auth to return a fake token so no real OAuth request is made
@@ -116,6 +120,16 @@ describe("Test Gemini GenerativeModel Instrumentation", () => {
   after(() => {
     if (originalGetAccessToken) {
       GoogleAuth.prototype.getAccessToken = originalGetAccessToken;
+    }
+    if (origProjectId === undefined) {
+      delete process.env.VERTEXAI_PROJECT_ID;
+    } else {
+      process.env.VERTEXAI_PROJECT_ID = origProjectId;
+    }
+    if (origLocation === undefined) {
+      delete process.env.VERTEXAI_LOCATION;
+    } else {
+      process.env.VERTEXAI_LOCATION = origLocation;
     }
   });
 

--- a/packages/instrumentation-vertexai/tests/gemini.test.ts
+++ b/packages/instrumentation-vertexai/tests/gemini.test.ts
@@ -19,30 +19,130 @@ import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
 import { VertexAIInstrumentation } from "../src/vertexai-instrumentation";
 import * as assert from "assert";
 import {
-  BasicTracerProvider,
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import type * as vertexAiImport from "@google-cloud/vertexai";
+import { GoogleAuth } from "google-auth-library";
+import { Polly, setupMocha as setupPolly } from "@pollyjs/core";
+import NodeHttpAdapter from "@pollyjs/adapter-node-http";
+import FetchAdapter from "@pollyjs/adapter-fetch";
+import {
+  ATTR_GEN_AI_REQUEST_MAX_TOKENS,
+  ATTR_GEN_AI_REQUEST_MODEL,
+  ATTR_GEN_AI_REQUEST_TOP_P,
+  ATTR_GEN_AI_RESPONSE_MODEL,
+  ATTR_GEN_AI_SYSTEM,
+} from "@opentelemetry/semantic-conventions/incubating";
 
 const memoryExporter = new InMemorySpanExporter();
 
-describe.skip("Test Gemini GenerativeModel Instrumentation", () => {
-  const provider = new BasicTracerProvider();
+Polly.register(NodeHttpAdapter);
+Polly.register(FetchAdapter);
+
+const GENERATE_CONTENT_RESPONSE = JSON.stringify({
+  candidates: [
+    {
+      content: {
+        parts: [
+          {
+            text: "Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine.",
+          },
+        ],
+        role: "model",
+      },
+      finishReason: "STOP",
+      index: 0,
+    },
+  ],
+  usageMetadata: {
+    promptTokenCount: 6,
+    candidatesTokenCount: 14,
+    totalTokenCount: 20,
+  },
+});
+
+const STREAM_CONTENT_RESPONSE =
+  `data: ${JSON.stringify({
+    candidates: [
+      {
+        content: {
+          parts: [
+            { text: "The four cardinal directions are North, South, East, and West." },
+          ],
+          role: "model",
+        },
+        finishReason: "STOP",
+        index: 0,
+      },
+    ],
+    usageMetadata: {
+      promptTokenCount: 9,
+      candidatesTokenCount: 13,
+      totalTokenCount: 22,
+    },
+  })}\n\n`;
+
+describe("Test Gemini GenerativeModel Instrumentation", () => {
+  const provider = new NodeTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+  });
   let instrumentation: VertexAIInstrumentation;
   let contextManager: AsyncHooksContextManager;
   let vertexAi: typeof vertexAiImport;
+  let originalGetAccessToken: typeof GoogleAuth.prototype.getAccessToken;
 
-  before(() => {
-    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
-    instrumentation = new VertexAIInstrumentation();
-    instrumentation.setTracerProvider(provider);
-    vertexAi = require("@google-cloud/vertexai");
+  setupPolly({
+    adapters: ["node-http", "fetch"],
+    mode: "passthrough",
   });
 
-  beforeEach(() => {
+  before(async () => {
+    process.env.VERTEXAI_PROJECT_ID = "test-project";
+    process.env.VERTEXAI_LOCATION = "us-central1";
+    // Stub Google Auth to return a fake token so no real OAuth request is made
+    originalGetAccessToken = GoogleAuth.prototype.getAccessToken;
+    GoogleAuth.prototype.getAccessToken = () =>
+      Promise.resolve("fake-token") as any;
+
+    instrumentation = new VertexAIInstrumentation();
+    instrumentation.setTracerProvider(provider);
+    instrumentation.enable();
+    vertexAi = require("@google-cloud/vertexai");
+    instrumentation.manuallyInstrument(vertexAi);
+  });
+
+  after(() => {
+    if (originalGetAccessToken) {
+      GoogleAuth.prototype.getAccessToken = originalGetAccessToken;
+    }
+  });
+
+  beforeEach(function () {
     contextManager = new AsyncHooksContextManager().enable();
     context.setGlobalContextManager(contextManager);
+
+    const { server } = this.polly as Polly;
+    // Intercept all VertexAI API calls and return mock responses
+    server
+      .post(
+        "https://us-central1-aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/publishers/google/models/gemini-pro-vision:generateContent",
+      )
+      .intercept((_req, res) => {
+        res.status(200).json(JSON.parse(GENERATE_CONTENT_RESPONSE));
+      });
+
+    server
+      .post(
+        "https://us-central1-aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/publishers/google/models/gemini-pro-vision:streamGenerateContent",
+      )
+      .intercept((_req, res) => {
+        res
+          .status(200)
+          .setHeader("content-type", "text/event-stream")
+          .send(STREAM_CONTENT_RESPONSE);
+      });
   });
 
   afterEach(() => {
@@ -52,13 +152,13 @@ describe.skip("Test Gemini GenerativeModel Instrumentation", () => {
 
   it("should set request and response attributes in span for Text prompts with non-stream response", async () => {
     const vertexAI = new vertexAi.VertexAI({
-      project: process.env.VERTEXAI_PROJECT_ID ?? "",
-      location: process.env.VERTEXAI_LOCATION ?? "",
+      project: process.env.VERTEXAI_PROJECT_ID ?? "test-project",
+      location: process.env.VERTEXAI_LOCATION ?? "us-central1",
     });
 
     const model = "gemini-pro-vision";
 
-    const generativeModel = vertexAI.preview.getGenerativeModel({
+    const generativeModel = vertexAI.getGenerativeModel({
       model,
       generationConfig: {
         topP: 0.9,
@@ -100,13 +200,13 @@ describe.skip("Test Gemini GenerativeModel Instrumentation", () => {
 
   it("should set request and response attributes in span for Text prompts with streaming response", async () => {
     const vertexAI = new vertexAi.VertexAI({
-      project: process.env.VERTEXAI_PROJECT_ID ?? "",
-      location: process.env.VERTEXAI_LOCATION ?? "",
+      project: process.env.VERTEXAI_PROJECT_ID ?? "test-project",
+      location: process.env.VERTEXAI_LOCATION ?? "us-central1",
     });
 
     const model = "gemini-pro-vision";
 
-    const generativeModel = vertexAI.preview.getGenerativeModel({
+    const generativeModel = vertexAI.getGenerativeModel({
       model,
       generationConfig: {
         topP: 0.9,
@@ -124,10 +224,14 @@ describe.skip("Test Gemini GenerativeModel Instrumentation", () => {
     };
     const responseStream = await generativeModel.generateContentStream(request);
 
-    const fullTextResponse = [];
-    for await (const item of responseStream.stream) {
-      fullTextResponse.push(item.candidates![0].content.parts[0].text);
+    // Consume the stream
+    for await (const _item of responseStream.stream) {
+      // intentionally empty — drain the stream so the span is finalized
     }
+
+    const aggregatedResponse = await responseStream.response;
+    const fullTextResponse =
+      aggregatedResponse.candidates![0].content.parts[0].text;
 
     assert.ok(fullTextResponse);
 
@@ -146,12 +250,9 @@ describe.skip("Test Gemini GenerativeModel Instrumentation", () => {
     assert.strictEqual(attributes["gen_ai.prompt.0.role"], "user");
     assert.strictEqual(attributes[ATTR_GEN_AI_RESPONSE_MODEL], model);
     assert.strictEqual(attributes["gen_ai.completion.0.role"], "model");
-
-    fullTextResponse.forEach((resp, index) => {
-      assert.strictEqual(
-        attributes[`gen_ai.completion.${index}.content`],
-        resp,
-      );
-    });
+    assert.strictEqual(
+      attributes["gen_ai.completion.0.content"],
+      fullTextResponse,
+    );
   });
 });

--- a/packages/instrumentation-vertexai/tests/palm2.test.ts
+++ b/packages/instrumentation-vertexai/tests/palm2.test.ts
@@ -28,6 +28,8 @@ import { google } from "@google-cloud/aiplatform/build/protos/protos";
 
 const memoryExporter = new InMemorySpanExporter();
 
+// PaLM2 (AIPlatform) uses gRPC which cannot be intercepted by Polly.js HTTP adapters.
+// Additionally, PaLM2 models are deprecated by Google. These tests remain skipped.
 describe.skip("Test PaLM2 PredictionServiceClient Instrumentation", () => {
   const provider = new BasicTracerProvider();
   let instrumentation: AIPlatformInstrumentation;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,7 +135,7 @@ importers:
         version: 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation':
         specifier: ^0.203.0
-        version: 0.203.0(@opentelemetry/api@1.9.0)
+        version: 0.203.0(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
       '@opentelemetry/semantic-conventions':
         specifier: ^1.40.0
         version: 1.40.0
@@ -163,13 +163,13 @@ importers:
         version: 6.0.7
       '@pollyjs/adapter-node-http':
         specifier: ^6.0.6
-        version: 6.0.6
+        version: 6.0.6(supports-color@10.0.0)
       '@pollyjs/core':
         specifier: ^6.0.6
         version: 6.0.6
       '@pollyjs/persister-fs':
         specifier: ^6.0.6
-        version: 6.0.6
+        version: 6.0.6(supports-color@10.0.0)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
@@ -190,7 +190,7 @@ importers:
         version: 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation':
         specifier: ^0.203.0
-        version: 0.203.0(@opentelemetry/api@1.9.0)
+        version: 0.203.0(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
       '@opentelemetry/semantic-conventions':
         specifier: ^1.40.0
         version: 1.40.0
@@ -218,13 +218,13 @@ importers:
         version: 6.0.7
       '@pollyjs/adapter-node-http':
         specifier: ^6.0.6
-        version: 6.0.6
+        version: 6.0.6(supports-color@10.0.0)
       '@pollyjs/core':
         specifier: ^6.0.6
         version: 6.0.6
       '@pollyjs/persister-fs':
         specifier: ^6.0.6
-        version: 6.0.6
+        version: 6.0.6(supports-color@10.0.0)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
@@ -242,7 +242,7 @@ importers:
         version: 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation':
         specifier: ^0.203.0
-        version: 0.203.0(@opentelemetry/api@1.9.0)
+        version: 0.203.0(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
       '@opentelemetry/semantic-conventions':
         specifier: ^1.38.0
         version: 1.38.0
@@ -261,13 +261,13 @@ importers:
         version: 2.0.1(@opentelemetry/api@1.9.0)
       '@pollyjs/adapter-node-http':
         specifier: ^6.0.6
-        version: 6.0.6
+        version: 6.0.6(supports-color@10.0.0)
       '@pollyjs/core':
         specifier: ^6.0.6
         version: 6.0.6
       '@pollyjs/persister-fs':
         specifier: ^6.0.6
-        version: 6.0.6
+        version: 6.0.6(supports-color@10.0.0)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
@@ -288,7 +288,7 @@ importers:
         version: 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation':
         specifier: ^0.203.0
-        version: 0.203.0(@opentelemetry/api@1.9.0)
+        version: 0.203.0(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
       '@opentelemetry/semantic-conventions':
         specifier: ^1.38.0
         version: 1.38.0
@@ -307,13 +307,13 @@ importers:
         version: 2.0.1(@opentelemetry/api@1.9.0)
       '@pollyjs/adapter-node-http':
         specifier: ^6.0.6
-        version: 6.0.6
+        version: 6.0.6(supports-color@10.0.0)
       '@pollyjs/core':
         specifier: ^6.0.6
         version: 6.0.6
       '@pollyjs/persister-fs':
         specifier: ^6.0.6
-        version: 6.0.6
+        version: 6.0.6(supports-color@10.0.0)
       '@smithy/config-resolver':
         specifier: ^4.4.0
         version: 4.4.6
@@ -343,7 +343,7 @@ importers:
         version: 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation':
         specifier: ^0.203.0
-        version: 0.203.0(@opentelemetry/api@1.9.0)
+        version: 0.203.0(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
       '@opentelemetry/semantic-conventions':
         specifier: ^1.40.0
         version: 1.40.0
@@ -377,13 +377,13 @@ importers:
         version: 6.0.7
       '@pollyjs/adapter-node-http':
         specifier: ^6.0.6
-        version: 6.0.6
+        version: 6.0.6(supports-color@10.0.0)
       '@pollyjs/core':
         specifier: ^6.0.6
         version: 6.0.6
       '@pollyjs/persister-fs':
         specifier: ^6.0.6
-        version: 6.0.6
+        version: 6.0.6(supports-color@10.0.0)
       '@traceloop/instrumentation-bedrock':
         specifier: workspace:*
         version: link:../instrumentation-bedrock
@@ -413,7 +413,7 @@ importers:
         version: 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation':
         specifier: ^0.203.0
-        version: 0.203.0(@opentelemetry/api@1.9.0)
+        version: 0.203.0(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
       '@opentelemetry/semantic-conventions':
         specifier: ^1.38.0
         version: 1.38.0
@@ -429,7 +429,7 @@ importers:
     devDependencies:
       '@llamaindex/openai':
         specifier: ^0.4.10
-        version: 0.4.12(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(encoding@0.1.13)(ws@8.18.3)(zod@3.25.76)
+        version: 0.4.12(@llamaindex/core@0.6.17)(@llamaindex/env@0.1.30)(encoding@0.1.13)(ws@8.18.3)(zod@3.25.76)
       '@opentelemetry/context-async-hooks':
         specifier: ^2.0.1
         version: 2.0.1(@opentelemetry/api@1.9.0)
@@ -438,13 +438,13 @@ importers:
         version: 2.0.1(@opentelemetry/api@1.9.0)
       '@pollyjs/adapter-node-http':
         specifier: ^6.0.6
-        version: 6.0.6
+        version: 6.0.6(supports-color@10.0.0)
       '@pollyjs/core':
         specifier: ^6.0.6
         version: 6.0.6
       '@pollyjs/persister-fs':
         specifier: ^6.0.6
-        version: 6.0.6
+        version: 6.0.6(supports-color@10.0.0)
       '@types/lodash':
         specifier: ^4.14.0
         version: 4.17.20
@@ -453,7 +453,7 @@ importers:
         version: 10.0.10
       llamaindex:
         specifier: ^0.12.1
-        version: 0.12.1(@modelcontextprotocol/sdk@1.25.2(@cfworker/json-schema@4.1.1)(hono@4.11.4)(zod@3.25.76))(hono@4.11.4)(p-retry@6.2.1)(rxjs@7.8.2)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@3.25.76)
+        version: 0.12.1(@modelcontextprotocol/sdk@1.25.2(@cfworker/json-schema@4.1.1)(hono@4.11.4)(supports-color@10.0.0)(zod@3.25.76))(hono@4.11.4)(p-retry@6.2.1)(rxjs@7.8.2)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@3.25.76)
       ts-mocha:
         specifier: ^11.1.0
         version: 11.1.0(mocha@11.7.1)(ts-node@10.9.2(@types/node@24.0.15)(typescript@5.9.3))(tsconfig-paths@4.2.0)
@@ -468,7 +468,7 @@ importers:
         version: 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation':
         specifier: ^0.203.0
-        version: 0.203.0(@opentelemetry/api@1.9.0)
+        version: 0.203.0(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
       '@opentelemetry/semantic-conventions':
         specifier: ^1.38.0
         version: 1.38.0
@@ -481,7 +481,7 @@ importers:
     devDependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.25.2
-        version: 1.25.2(@cfworker/json-schema@4.1.1)(hono@4.11.4)(zod@3.25.76)
+        version: 1.25.2(@cfworker/json-schema@4.1.1)(hono@4.11.4)(supports-color@10.0.0)(zod@3.25.76)
       '@opentelemetry/context-async-hooks':
         specifier: ^2.0.1
         version: 2.0.1(@opentelemetry/api@1.9.0)
@@ -493,13 +493,13 @@ importers:
         version: 6.0.7
       '@pollyjs/adapter-node-http':
         specifier: ^6.0.6
-        version: 6.0.6
+        version: 6.0.6(supports-color@10.0.0)
       '@pollyjs/core':
         specifier: ^6.0.6
         version: 6.0.6
       '@pollyjs/persister-fs':
         specifier: ^6.0.6
-        version: 6.0.6
+        version: 6.0.6(supports-color@10.0.0)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
@@ -520,7 +520,7 @@ importers:
         version: 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation':
         specifier: ^0.203.0
-        version: 0.203.0(@opentelemetry/api@1.9.0)
+        version: 0.203.0(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
       '@opentelemetry/semantic-conventions':
         specifier: ^1.40.0
         version: 1.40.0
@@ -548,13 +548,13 @@ importers:
         version: 6.0.7
       '@pollyjs/adapter-node-http':
         specifier: ^6.0.6
-        version: 6.0.6
+        version: 6.0.6(supports-color@10.0.0)
       '@pollyjs/core':
         specifier: ^6.0.6
         version: 6.0.6
       '@pollyjs/persister-fs':
         specifier: ^6.0.6
-        version: 6.0.6
+        version: 6.0.6(supports-color@10.0.0)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
@@ -587,7 +587,7 @@ importers:
         version: 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation':
         specifier: ^0.203.0
-        version: 0.203.0(@opentelemetry/api@1.9.0)
+        version: 0.203.0(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
       '@opentelemetry/semantic-conventions':
         specifier: ^1.38.0
         version: 1.38.0
@@ -618,7 +618,7 @@ importers:
         version: 6.0.6
       '@pollyjs/persister-fs':
         specifier: ^6.0.6
-        version: 6.0.6
+        version: 6.0.6(supports-color@10.0.0)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
@@ -636,7 +636,7 @@ importers:
         version: 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation':
         specifier: ^0.203.0
-        version: 0.203.0(@opentelemetry/api@1.9.0)
+        version: 0.203.0(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
       '@traceloop/ai-semantic-conventions':
         specifier: workspace:*
         version: link:../ai-semantic-conventions
@@ -655,13 +655,13 @@ importers:
         version: 2.0.1(@opentelemetry/api@1.9.0)
       '@pollyjs/adapter-node-http':
         specifier: ^6.0.6
-        version: 6.0.6
+        version: 6.0.6(supports-color@10.0.0)
       '@pollyjs/core':
         specifier: ^6.0.6
         version: 6.0.6
       '@pollyjs/persister-fs':
         specifier: ^6.0.6
-        version: 6.0.6
+        version: 6.0.6(supports-color@10.0.0)
       '@qdrant/js-client-rest':
         specifier: ^1.16.2
         version: 1.16.2(typescript@5.9.3)
@@ -685,7 +685,7 @@ importers:
         version: 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation':
         specifier: ^0.203.0
-        version: 0.203.0(@opentelemetry/api@1.9.0)
+        version: 0.203.0(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
       '@opentelemetry/semantic-conventions':
         specifier: ^1.38.0
         version: 1.38.0
@@ -707,13 +707,13 @@ importers:
         version: 2.0.1(@opentelemetry/api@1.9.0)
       '@pollyjs/adapter-node-http':
         specifier: ^6.0.6
-        version: 6.0.6
+        version: 6.0.6(supports-color@10.0.0)
       '@pollyjs/core':
         specifier: ^6.0.6
         version: 6.0.6
       '@pollyjs/persister-fs':
         specifier: ^6.0.6
-        version: 6.0.6
+        version: 6.0.6(supports-color@10.0.0)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
@@ -746,7 +746,7 @@ importers:
         version: 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation':
         specifier: ^0.203.0
-        version: 0.203.0(@opentelemetry/api@1.9.0)
+        version: 0.203.0(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
       '@opentelemetry/semantic-conventions':
         specifier: ^1.38.0
         version: 1.38.0
@@ -762,19 +762,34 @@ importers:
     devDependencies:
       '@google-cloud/aiplatform':
         specifier: ^4.4.0
-        version: 4.4.0
+        version: 4.4.0(supports-color@10.0.0)
       '@google-cloud/vertexai':
         specifier: ^1.10.0
-        version: 1.10.0(encoding@0.1.13)
+        version: 1.10.0(encoding@0.1.13)(supports-color@10.0.0)
       '@opentelemetry/context-async-hooks':
         specifier: ^2.0.1
         version: 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base':
         specifier: ^2.0.1
         version: 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node':
+        specifier: ^2.0.1
+        version: 2.0.1(@opentelemetry/api@1.9.0)
+      '@pollyjs/adapter-fetch':
+        specifier: ^6.0.7
+        version: 6.0.7
+      '@pollyjs/adapter-node-http':
+        specifier: ^6.0.6
+        version: 6.0.6(supports-color@10.0.0)
+      '@pollyjs/core':
+        specifier: ^6.0.6
+        version: 6.0.6
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
+      google-auth-library:
+        specifier: ^9.0.0
+        version: 9.15.1(encoding@0.1.13)(supports-color@10.0.0)
       ts-mocha:
         specifier: ^11.1.0
         version: 11.1.0(mocha@11.7.1)(ts-node@10.9.2(@types/node@24.0.15)(typescript@5.9.3))(tsconfig-paths@4.2.0)
@@ -795,10 +810,10 @@ importers:
         version: 4.10.2
       '@google-cloud/aiplatform':
         specifier: ^4.4.0
-        version: 4.4.0
+        version: 4.4.0(supports-color@10.0.0)
       '@google-cloud/vertexai':
         specifier: ^1.10.0
-        version: 1.10.0(encoding@0.1.13)
+        version: 1.10.0(encoding@0.1.13)(supports-color@10.0.0)
       '@langchain/aws':
         specifier: ^1.0.0
         version: 1.3.4(@langchain/core@1.1.39(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))
@@ -819,19 +834,19 @@ importers:
         version: 1.0.1(@langchain/core@1.1.39(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))
       '@llamaindex/openai':
         specifier: ^0.4.10
-        version: 0.4.12(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(encoding@0.1.13)(ws@8.18.3)(zod@3.25.76)
+        version: 0.4.12(@llamaindex/core@0.6.17)(@llamaindex/env@0.1.30)(encoding@0.1.13)(ws@8.18.3)(zod@3.25.76)
       '@modelcontextprotocol/sdk':
         specifier: ^1.25.2
-        version: 1.25.2(@cfworker/json-schema@4.1.1)(hono@4.11.4)(zod@3.25.76)
+        version: 1.25.2(@cfworker/json-schema@4.1.1)(hono@4.11.4)(supports-color@10.0.0)(zod@3.25.76)
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.0
       '@opentelemetry/instrumentation':
         specifier: ^0.203.0
-        version: 0.203.0(@opentelemetry/api@1.9.0)
+        version: 0.203.0(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
       '@opentelemetry/sdk-node':
         specifier: ^0.203.0
-        version: 0.203.0(@opentelemetry/api@1.9.0)
+        version: 0.203.0(@opentelemetry/api@1.9.0)(supports-color@10.0.0)
       '@opentelemetry/sdk-trace-base':
         specifier: ^2.0.1
         version: 2.0.1(@opentelemetry/api@1.9.0)
@@ -879,7 +894,7 @@ importers:
         version: 0.5.16(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
       llamaindex:
         specifier: ^0.12.1
-        version: 0.12.1(@modelcontextprotocol/sdk@1.25.2(@cfworker/json-schema@4.1.1)(hono@4.11.4)(zod@3.25.76))(hono@4.11.4)(p-retry@6.2.1)(rxjs@7.8.2)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@3.25.76)
+        version: 0.12.1(@modelcontextprotocol/sdk@1.25.2(@cfworker/json-schema@4.1.1)(hono@4.11.4)(supports-color@10.0.0)(zod@3.25.76))(hono@4.11.4)(p-retry@6.2.1)(rxjs@7.8.2)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@3.25.76)
       openai:
         specifier: ^6.32.0
         version: 6.32.0(ws@8.18.3)(zod@3.25.76)
@@ -3267,6 +3282,9 @@ packages:
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
     deprecated: This package is an implementation detail of Lerna and is no longer published separately.
 
+  '@llamaindex/core@0.6.17':
+    resolution: {integrity: sha512-ZdELOt3qsuNkZy+iUdEPMp2KxKGUa+qE+B67RkN90gi47Bq+ED/pUFkJ3fstDjGvEmY5CuRKrrNgVhVbZQaHkA==}
+
   '@llamaindex/core@0.6.22':
     resolution: {integrity: sha512-/BXyemkvpxMaUhOkbwJ2PTvzKjSWkL8+6QLpz/n+pk8xBwMMe1GVBgli/J57gCyi8GbrlBafBj6GaPOgWub2Eg==}
 
@@ -3570,64 +3588,76 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-arm64-gnu@21.3.2':
     resolution: {integrity: sha512-PsCZC3emzGKMM+7n8Qsp7RsP6v3qwAwmBZncgBUNq1QMg9VrFrsKfMcZtJdwkdMzK3jQwHn20nSM8TMO5/aLsQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-arm64-gnu@21.6.10':
     resolution: {integrity: sha512-4ZSjvCjnBT0WpGdF12hvgLWmok4WftaE09fOWWrMm4b2m8F/5yKgU6usPFTehQa5oqTp08KW60kZMLaOQHOJQg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@19.8.4':
     resolution: {integrity: sha512-0q8r8I8WCsY3xowDI2j109SCUSkFns/BJ40aCfRh9hhrtaIIc5qXUw2YFTjxUZNcRJXx9j9+hTe9jBkUSIGvCw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-arm64-musl@21.3.2':
     resolution: {integrity: sha512-lA/fNora74mBFSQp6HG4FfOkoUBnAfraF7Cc9TR4Z50lZDgXFMPf0Gn4Qdvpphl3ydmsU8bXmzu/ckHWJwuELA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-arm64-musl@21.6.10':
     resolution: {integrity: sha512-lNzlTsgr7nY56ddIpLTzYZTuNA3FoeWb9Ald07pCWc0EHSZ0W4iatJ+NNnj/QLINW8HWUehE9mAV5qZlhVFBmg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@19.8.4':
     resolution: {integrity: sha512-XcRBNe0ws7KB0PMcUlpQqzzjjxMP8VdqirBz7CfB2XQ8xKmP3370p0cDvqs/4oKDHK4PCkmvVFX60tzakutylA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-gnu@21.3.2':
     resolution: {integrity: sha512-gpBmox+M9vmUDJppp8nY73RgpHU9QJE201Ey+YBbgEn+TSaFwkxdwqmsJGnysqNpUU9I6VWEd3bFcEZNczTHWA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-gnu@21.6.10':
     resolution: {integrity: sha512-nJxUtzcHwk8TgDdcqUmbJnEMV3baQxmdWn77d1NTP4cG677A7jdV93hbnCcw+AQonaFLUzDwJOIX8eIPZ32GLw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@19.8.4':
     resolution: {integrity: sha512-JB4tAuZBCF0yqSnKF3pHXa0b7LA3ebi3Bw08QmMr//ON4aU+eXURGBuj9XvULD2prY+gpBrvf+MsG1XJAHL6Zg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-x64-musl@21.3.2':
     resolution: {integrity: sha512-QOQiEKotsIb6u3J4KQlfqfQFy6PXfJe56sCeoQAYuRUMXCiuTPr+Z2V43v1UcAZOu4beDEcP+saRN7EucsWeHA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-x64-musl@21.6.10':
     resolution: {integrity: sha512-+VwITTQW9wswP7EvFzNOucyaU86l2UcO6oYxFiwNvRioTlDOE5U7lxYmCgj3OHeGCmy9jhXlujdD+t3OhOT3gQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@19.8.4':
     resolution: {integrity: sha512-WvQag/pN9ofRWRDvOZxj3jvJoTetlvV1uyirnDrhupRgi+Fj67OlGGt2zVUHaXFGEa1MfCEG6Vhk6152m4KyaQ==}
@@ -4049,56 +4079,67 @@ packages:
     resolution: {integrity: sha512-RkdOTu2jK7brlu+ZwjMIZfdV2sSYHK2qR08FUWcIoqJC2eywHbXr0L8T/pONFwkGukQqERDheaGTeedG+rra6Q==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.45.1':
     resolution: {integrity: sha512-3kJ8pgfBt6CIIr1o+HQA7OZ9mp/zDk3ctekGl9qn/pRBgrRgfwiffaUmqioUGN9hv0OHv2gxmvdKOkARCtRb8Q==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.45.1':
     resolution: {integrity: sha512-k3dOKCfIVixWjG7OXTCOmDfJj3vbdhN0QYEqB+OuGArOChek22hn7Uy5A/gTDNAcCy5v2YcXRJ/Qcnm4/ma1xw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.45.1':
     resolution: {integrity: sha512-PmI1vxQetnM58ZmDFl9/Uk2lpBBby6B6rF4muJc65uZbxCs0EA7hhKCk2PKlmZKuyVSHAyIw3+/SiuMLxKxWog==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.45.1':
     resolution: {integrity: sha512-9UmI0VzGmNJ28ibHW2GpE2nF0PBQqsyiS4kcJ5vK+wuwGnV5RlqdczVocDSUfGX/Na7/XINRVoUgJyFIgipoRg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.45.1':
     resolution: {integrity: sha512-7nR2KY8oEOUTD3pBAxIBBbZr0U7U+R9HDTPNy+5nVVHDXI4ikYniH1oxQz9VoB5PbBU1CZuDGHkLJkd3zLMWsg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.45.1':
     resolution: {integrity: sha512-nlcl3jgUultKROfZijKjRQLUu9Ma0PeNv/VFHkZiKbXTBQXhpytS8CIj5/NfBeECZtY2FJQubm6ltIxm/ftxpw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.45.1':
     resolution: {integrity: sha512-HJV65KLS51rW0VY6rvZkiieiBnurSzpzore1bMKAhunQiECPuxsROvyeaot/tcK3A3aGnI+qTHqisrpSgQrpgA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.45.1':
     resolution: {integrity: sha512-NITBOCv3Qqc6hhwFt7jLV78VEO/il4YcBzoMGGNxznLgRQf43VQDae0aAzKiBeEPIxnDrACiMgbqjuihx08OOw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.45.1':
     resolution: {integrity: sha512-+E/lYl6qu1zqgPEnTrs4WysQtvc/Sh4fC2nByfFExqgYrqkKWp1tWIbe+ELhixnenSpBbLXNi6vbEEJ8M7fiHw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.45.1':
     resolution: {integrity: sha512-a6WIAp89p3kpNoYStITT9RbTbTnqarU7D8N8F2CV+4Cl9fwCOZraLVuVFvlpsW0SbIiYtEnhCZBPLoNdRkjQFw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.45.1':
     resolution: {integrity: sha512-T5Bi/NS3fQiJeYdGvRpTAP5P02kqSOpqiopwhj0uaXB6nzs5JVi2XMJb18JUSKhCOX8+UE1UKQufyD6Or48dJg==}
@@ -5350,12 +5391,14 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   chromadb-js-bindings-linux-x64-gnu@1.0.1:
     resolution: {integrity: sha512-Aw4WB+ojLgwcbopOLz2JnrmoCSRPUPmP9TBz1RUaZ3qTFINoyULkT1l6aD/O7leBZFYxRMLFQRfiCKp5uU+xYg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   chromadb-js-bindings-win32-x64-msvc@1.0.1:
     resolution: {integrity: sha512-RNTJMrlUaiwUB6BODV7c5UqKW0EXzSH/vYBT/j7ZcSH2njzl18szDnirozCC4P4FNPKIbx5u1YzWCZZ9RlgjjQ==}
@@ -10634,7 +10677,7 @@ snapshots:
       '@babel/traverse': 7.28.0
       '@babel/types': 7.28.1
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@10.0.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -10686,7 +10729,7 @@ snapshots:
       '@babel/core': 7.28.0
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@10.0.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.10
     transitivePeerDependencies:
@@ -11316,7 +11359,7 @@ snapshots:
       '@babel/parser': 7.28.0
       '@babel/template': 7.27.2
       '@babel/types': 7.28.1
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@10.0.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11570,7 +11613,7 @@ snapshots:
   '@eslint/config-array@0.21.0':
     dependencies:
       '@eslint/object-schema': 2.1.6
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@10.0.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -11584,7 +11627,7 @@ snapshots:
   '@eslint/eslintrc@3.3.1':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@10.0.0)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -11607,12 +11650,6 @@ snapshots:
   '@finom/zod-to-json-schema@3.24.11(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
-
-  '@google-cloud/aiplatform@4.4.0':
-    dependencies:
-      google-gax: 5.0.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@google-cloud/aiplatform@4.4.0(supports-color@10.0.0)':
     dependencies:
@@ -11640,13 +11677,6 @@ snapshots:
       '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.40.0
       gcp-metadata: 6.1.1(encoding@0.1.13)(supports-color@10.0.0)
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
-  '@google-cloud/vertexai@1.10.0(encoding@0.1.13)':
-    dependencies:
-      google-auth-library: 9.15.1(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -12158,7 +12188,7 @@ snapshots:
       chromadb: 3.0.9
       cohere-ai: 7.17.1(encoding@0.1.13)
       fast-xml-parser: 5.5.8
-      google-auth-library: 10.1.0
+      google-auth-library: 10.1.0(supports-color@10.0.0)
       hnswlib-node: 3.0.0
       html-to-text: 9.0.5
       ignore: 7.0.5
@@ -12363,6 +12393,17 @@ snapshots:
       - supports-color
       - typescript
 
+  '@llamaindex/core@0.6.17':
+    dependencies:
+      '@llamaindex/env': 0.1.30
+      '@types/node': 24.0.15
+      magic-bytes.js: 1.12.1
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.0(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@huggingface/transformers'
+      - gpt-tokenizer
+
   '@llamaindex/core@0.6.22':
     dependencies:
       '@finom/zod-to-json-schema': 3.24.11(zod@3.25.76)
@@ -12388,9 +12429,9 @@ snapshots:
       tree-sitter: 0.22.4
       web-tree-sitter: 0.24.7
 
-  '@llamaindex/openai@0.4.12(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(encoding@0.1.13)(ws@8.18.3)(zod@3.25.76)':
+  '@llamaindex/openai@0.4.12(@llamaindex/core@0.6.17)(@llamaindex/env@0.1.30)(encoding@0.1.13)(ws@8.18.3)(zod@3.25.76)':
     dependencies:
-      '@llamaindex/core': 0.6.22
+      '@llamaindex/core': 0.6.17
       '@llamaindex/env': 0.1.30
       openai: 4.104.0(encoding@0.1.13)(ws@8.18.3)(zod@3.25.76)
     transitivePeerDependencies:
@@ -12406,32 +12447,11 @@ snapshots:
       rxjs: 7.8.2
       zod: 3.25.76
 
-  '@llamaindex/workflow-core@1.3.3(@modelcontextprotocol/sdk@1.25.2(@cfworker/json-schema@4.1.1)(hono@4.11.4)(zod@3.25.76))(hono@4.11.4)(p-retry@6.2.1)(rxjs@7.8.2)(zod@3.25.76)':
-    optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.25.2(@cfworker/json-schema@4.1.1)(hono@4.11.4)(zod@3.25.76)
-      hono: 4.11.4
-      p-retry: 6.2.1
-      rxjs: 7.8.2
-      zod: 3.25.76
-
   '@llamaindex/workflow@1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.25.2(@cfworker/json-schema@4.1.1)(hono@4.11.4)(supports-color@10.0.0)(zod@3.25.76))(hono@4.11.4)(p-retry@6.2.1)(rxjs@7.8.2)(zod@3.25.76)':
     dependencies:
       '@llamaindex/core': 0.6.22
       '@llamaindex/env': 0.1.30
       '@llamaindex/workflow-core': 1.3.3(@modelcontextprotocol/sdk@1.25.2(@cfworker/json-schema@4.1.1)(hono@4.11.4)(supports-color@10.0.0)(zod@3.25.76))(hono@4.11.4)(p-retry@6.2.1)(rxjs@7.8.2)(zod@3.25.76)
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - hono
-      - next
-      - p-retry
-      - rxjs
-      - zod
-
-  '@llamaindex/workflow@1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.25.2(@cfworker/json-schema@4.1.1)(hono@4.11.4)(zod@3.25.76))(hono@4.11.4)(p-retry@6.2.1)(rxjs@7.8.2)(zod@3.25.76)':
-    dependencies:
-      '@llamaindex/core': 0.6.22
-      '@llamaindex/env': 0.1.30
-      '@llamaindex/workflow-core': 1.3.3(@modelcontextprotocol/sdk@1.25.2(@cfworker/json-schema@4.1.1)(hono@4.11.4)(zod@3.25.76))(hono@4.11.4)(p-retry@6.2.1)(rxjs@7.8.2)(zod@3.25.76)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - hono
@@ -12452,30 +12472,6 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.1.0(supports-color@10.0.0)
       express-rate-limit: 7.5.1(express@5.1.0(supports-color@10.0.0))
-      jose: 6.1.3
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.0
-      raw-body: 3.0.1
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.0(zod@3.25.76)
-    optionalDependencies:
-      '@cfworker/json-schema': 4.1.1
-    transitivePeerDependencies:
-      - hono
-      - supports-color
-
-  '@modelcontextprotocol/sdk@1.25.2(@cfworker/json-schema@4.1.1)(hono@4.11.4)(zod@3.25.76)':
-    dependencies:
-      '@hono/node-server': 1.19.9(hono@4.11.4)
-      ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
-      content-type: 1.0.5
-      cors: 2.8.5
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.0.6
-      express: 5.1.0
-      express-rate-limit: 7.5.1(express@5.1.0)
       jose: 6.1.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.0
@@ -12510,7 +12506,7 @@ snapshots:
     dependencies:
       agent-base: 7.1.4
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6(supports-color@10.0.0)
       lru-cache: 10.4.3
       socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
@@ -12520,7 +12516,7 @@ snapshots:
     dependencies:
       agent-base: 7.1.4
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6(supports-color@10.0.0)
       lru-cache: 11.2.4
       socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
@@ -13217,15 +13213,6 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.40.0
 
-  '@opentelemetry/instrumentation@0.203.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.203.0
-      import-in-the-middle: 1.14.2
-      require-in-the-middle: 7.5.2
-    transitivePeerDependencies:
-      - supports-color
-
   '@opentelemetry/instrumentation@0.203.0(@opentelemetry/api@1.9.0)(supports-color@10.0.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -13288,34 +13275,6 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
-
-  '@opentelemetry/sdk-node@0.203.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.203.0
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-logs-otlp-grpc': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-logs-otlp-http': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-logs-otlp-proto': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-metrics-otlp-grpc': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-metrics-otlp-http': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-metrics-otlp-proto': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-prometheus': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-trace-otlp-grpc': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-trace-otlp-http': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-trace-otlp-proto': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-zipkin': 2.0.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/propagator-b3': 2.0.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/propagator-jaeger': 2.0.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-logs': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-metrics': 2.0.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-node': 2.0.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.40.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@opentelemetry/sdk-node@0.203.0(@opentelemetry/api@1.9.0)(supports-color@10.0.0)':
     dependencies:
@@ -13385,15 +13344,6 @@ snapshots:
       '@pollyjs/utils': 6.0.6
       to-arraybuffer: 1.0.1
 
-  '@pollyjs/adapter-node-http@6.0.6':
-    dependencies:
-      '@pollyjs/adapter': 6.0.6
-      '@pollyjs/utils': 6.0.6
-      lodash-es: 4.17.21
-      nock: 13.5.6
-    transitivePeerDependencies:
-      - supports-color
-
   '@pollyjs/adapter-node-http@6.0.6(supports-color@10.0.0)':
     dependencies:
       '@pollyjs/adapter': 6.0.6
@@ -13419,19 +13369,6 @@ snapshots:
       route-recognizer: 0.3.4
       slugify: 1.6.6
 
-  '@pollyjs/node-server@6.0.6':
-    dependencies:
-      '@pollyjs/utils': 6.0.6
-      body-parser: 2.2.2
-      cors: 2.8.5
-      express: 4.21.2
-      fs-extra: 10.1.0
-      http-graceful-shutdown: 3.1.14
-      morgan: 1.10.1(supports-color@10.0.0)
-      nocache: 3.0.4
-    transitivePeerDependencies:
-      - supports-color
-
   '@pollyjs/node-server@6.0.6(supports-color@10.0.0)':
     dependencies:
       '@pollyjs/utils': 6.0.6
@@ -13442,13 +13379,6 @@ snapshots:
       http-graceful-shutdown: 3.1.14(supports-color@10.0.0)
       morgan: 1.10.1(supports-color@10.0.0)
       nocache: 3.0.4
-    transitivePeerDependencies:
-      - supports-color
-
-  '@pollyjs/persister-fs@6.0.6':
-    dependencies:
-      '@pollyjs/node-server': 6.0.6
-      '@pollyjs/persister': 6.0.6
     transitivePeerDependencies:
       - supports-color
 
@@ -14686,7 +14616,7 @@ snapshots:
       '@typescript-eslint/types': 8.38.0
       '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.38.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@10.0.0)
       eslint: 9.31.0(jiti@2.4.2)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -14696,7 +14626,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.38.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.38.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@10.0.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -14715,7 +14645,7 @@ snapshots:
       '@typescript-eslint/types': 8.38.0
       '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.9.3)
       '@typescript-eslint/utils': 8.38.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.9.3)
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@10.0.0)
       eslint: 9.31.0(jiti@2.4.2)
       ts-api-utils: 2.1.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -14730,7 +14660,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.38.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.38.0
       '@typescript-eslint/visitor-keys': 8.38.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@10.0.0)
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -14759,7 +14689,7 @@ snapshots:
   '@typespec/ts-http-runtime@0.3.0':
     dependencies:
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6(supports-color@10.0.0)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -14822,12 +14752,6 @@ snapshots:
   add-stream@1.0.0: {}
 
   address@1.2.2: {}
-
-  agent-base@6.0.2:
-    dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-    transitivePeerDependencies:
-      - supports-color
 
   agent-base@6.0.2(supports-color@10.0.0):
     dependencies:
@@ -15032,20 +14956,6 @@ snapshots:
   blueimp-md5@2.19.0: {}
 
   bmp-ts@1.0.9: {}
-
-  body-parser@2.2.2:
-    dependencies:
-      bytes: 3.1.2
-      content-type: 1.0.5
-      debug: 4.4.3(supports-color@10.2.2)
-      http-errors: 2.0.0
-      iconv-lite: 0.7.0
-      on-finished: 2.4.1
-      qs: 6.14.1
-      raw-body: 3.0.1
-      type-is: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
 
   body-parser@2.2.2(supports-color@10.0.0):
     dependencies:
@@ -15699,7 +15609,7 @@ snapshots:
   detect-port@1.6.1:
     dependencies:
       address: 1.2.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@10.0.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -15920,7 +15830,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@10.0.0)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -16012,46 +15922,6 @@ snapshots:
     dependencies:
       express: 5.1.0(supports-color@10.0.0)
 
-  express-rate-limit@7.5.1(express@5.1.0):
-    dependencies:
-      express: 5.1.0
-
-  express@4.21.2:
-    dependencies:
-      accepts: 1.3.8
-      array-flatten: 1.1.1
-      body-parser: 2.2.2
-      content-disposition: 0.5.4
-      content-type: 1.0.5
-      cookie: 0.7.1
-      cookie-signature: 1.0.6
-      debug: 2.6.9(supports-color@10.0.0)
-      depd: 2.0.0
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      finalhandler: 1.3.1(supports-color@10.0.0)
-      fresh: 0.5.2
-      http-errors: 2.0.0
-      merge-descriptors: 1.0.3
-      methods: 1.1.2
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      path-to-regexp: 0.1.12
-      proxy-addr: 2.0.7
-      qs: 6.14.1
-      range-parser: 1.2.1
-      safe-buffer: 5.2.1
-      send: 0.19.0(supports-color@10.0.0)
-      serve-static: 1.16.2(supports-color@10.0.0)
-      setprototypeof: 1.2.0
-      statuses: 2.0.1
-      type-is: 1.6.18
-      utils-merge: 1.0.1
-      vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
-
   express@4.21.2(supports-color@10.0.0):
     dependencies:
       accepts: 1.3.8
@@ -16084,38 +15954,6 @@ snapshots:
       statuses: 2.0.1
       type-is: 1.6.18
       utils-merge: 1.0.1
-      vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  express@5.1.0:
-    dependencies:
-      accepts: 2.0.0
-      body-parser: 2.2.2
-      content-disposition: 1.0.1
-      content-type: 1.0.5
-      cookie: 0.7.1
-      cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@10.2.2)
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      finalhandler: 2.1.0
-      fresh: 2.0.0
-      http-errors: 2.0.0
-      merge-descriptors: 2.0.0
-      mime-types: 3.0.2
-      on-finished: 2.4.1
-      once: 1.4.0
-      parseurl: 1.3.3
-      proxy-addr: 2.0.7
-      qs: 6.14.1
-      range-parser: 1.2.1
-      router: 2.2.0
-      send: 1.2.0
-      serve-static: 2.2.0
-      statuses: 2.0.1
-      type-is: 2.0.1
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
@@ -16251,17 +16089,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  finalhandler@2.1.0:
-    dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      statuses: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
-
   finalhandler@2.1.0(supports-color@10.0.0):
     dependencies:
       debug: 4.4.3(supports-color@10.0.0)
@@ -16323,7 +16150,7 @@ snapshots:
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@10.0.0)
 
   foreground-child@3.3.1:
     dependencies:
@@ -16400,17 +16227,6 @@ snapshots:
 
   function-bind@1.1.2: {}
 
-  gaxios@6.7.1(encoding@0.1.13):
-    dependencies:
-      extend: 3.0.2
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
-      is-stream: 2.0.1
-      node-fetch: 2.7.0(encoding@0.1.13)
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
   gaxios@6.7.1(encoding@0.1.13)(supports-color@10.0.0):
     dependencies:
       extend: 3.0.2
@@ -16422,29 +16238,12 @@ snapshots:
       - encoding
       - supports-color
 
-  gaxios@7.1.1:
-    dependencies:
-      extend: 3.0.2
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
-      node-fetch: 3.3.2
-    transitivePeerDependencies:
-      - supports-color
-
   gaxios@7.1.1(supports-color@10.0.0):
     dependencies:
       extend: 3.0.2
       https-proxy-agent: 7.0.6(supports-color@10.0.0)
       node-fetch: 3.3.2
     transitivePeerDependencies:
-      - supports-color
-
-  gcp-metadata@6.1.1(encoding@0.1.13):
-    dependencies:
-      gaxios: 6.7.1(encoding@0.1.13)
-      google-logging-utils: 0.0.2
-      json-bigint: 1.0.0
-    transitivePeerDependencies:
-      - encoding
       - supports-color
 
   gcp-metadata@6.1.1(encoding@0.1.13)(supports-color@10.0.0):
@@ -16454,14 +16253,6 @@ snapshots:
       json-bigint: 1.0.0
     transitivePeerDependencies:
       - encoding
-      - supports-color
-
-  gcp-metadata@7.0.1:
-    dependencies:
-      gaxios: 7.1.1
-      google-logging-utils: 1.1.1
-      json-bigint: 1.0.0
-    transitivePeerDependencies:
       - supports-color
 
   gcp-metadata@7.0.1(supports-color@10.0.0):
@@ -16591,18 +16382,6 @@ snapshots:
 
   globals@16.3.0: {}
 
-  google-auth-library@10.1.0:
-    dependencies:
-      base64-js: 1.5.1
-      ecdsa-sig-formatter: 1.0.11
-      gaxios: 7.1.1
-      gcp-metadata: 7.0.1
-      google-logging-utils: 1.1.1
-      gtoken: 8.0.0
-      jws: 4.0.1
-    transitivePeerDependencies:
-      - supports-color
-
   google-auth-library@10.1.0(supports-color@10.0.0):
     dependencies:
       base64-js: 1.5.1
@@ -16613,18 +16392,6 @@ snapshots:
       gtoken: 8.0.0(supports-color@10.0.0)
       jws: 4.0.1
     transitivePeerDependencies:
-      - supports-color
-
-  google-auth-library@9.15.1(encoding@0.1.13):
-    dependencies:
-      base64-js: 1.5.1
-      ecdsa-sig-formatter: 1.0.11
-      gaxios: 6.7.1(encoding@0.1.13)
-      gcp-metadata: 6.1.1(encoding@0.1.13)
-      gtoken: 7.1.0(encoding@0.1.13)
-      jws: 4.0.1
-    transitivePeerDependencies:
-      - encoding
       - supports-color
 
   google-auth-library@9.15.1(encoding@0.1.13)(supports-color@10.0.0):
@@ -16646,7 +16413,7 @@ snapshots:
       '@types/long': 4.0.2
       abort-controller: 3.0.0
       duplexify: 4.1.3
-      google-auth-library: 9.15.1(encoding@0.1.13)
+      google-auth-library: 9.15.1(encoding@0.1.13)(supports-color@10.0.0)
       node-fetch: 2.7.0(encoding@0.1.13)
       object-hash: 3.0.0
       proto3-json-serializer: 2.0.2
@@ -16655,22 +16422,6 @@ snapshots:
       uuid: 9.0.1
     transitivePeerDependencies:
       - encoding
-      - supports-color
-
-  google-gax@5.0.1:
-    dependencies:
-      '@grpc/grpc-js': 1.13.4
-      '@grpc/proto-loader': 0.7.15
-      abort-controller: 3.0.0
-      duplexify: 4.1.3
-      google-auth-library: 10.1.0
-      google-logging-utils: 1.1.1
-      node-fetch: 3.3.2
-      object-hash: 3.0.0
-      proto3-json-serializer: 3.0.1
-      protobufjs: 7.5.3
-      retry-request: 8.0.0
-    transitivePeerDependencies:
       - supports-color
 
   google-gax@5.0.1(supports-color@10.0.0):
@@ -16699,27 +16450,12 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  gtoken@7.1.0(encoding@0.1.13):
-    dependencies:
-      gaxios: 6.7.1(encoding@0.1.13)
-      jws: 4.0.1
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
   gtoken@7.1.0(encoding@0.1.13)(supports-color@10.0.0):
     dependencies:
       gaxios: 6.7.1(encoding@0.1.13)(supports-color@10.0.0)
       jws: 4.0.1
     transitivePeerDependencies:
       - encoding
-      - supports-color
-
-  gtoken@8.0.0:
-    dependencies:
-      gaxios: 7.1.1
-      jws: 4.0.1
-    transitivePeerDependencies:
       - supports-color
 
   gtoken@8.0.0(supports-color@10.0.0):
@@ -16828,23 +16564,9 @@ snapshots:
       statuses: 2.0.1
       toidentifier: 1.0.1
 
-  http-graceful-shutdown@3.1.14:
-    dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-    transitivePeerDependencies:
-      - supports-color
-
   http-graceful-shutdown@3.1.14(supports-color@10.0.0):
     dependencies:
       debug: 4.4.3(supports-color@10.0.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  http-proxy-agent@5.0.0:
-    dependencies:
-      '@tootallnate/once': 2.0.0
-      agent-base: 6.0.2
-      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -16859,14 +16581,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@10.2.2)
-    transitivePeerDependencies:
-      - supports-color
-
-  https-proxy-agent@5.0.1:
-    dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@10.0.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -16906,7 +16621,7 @@ snapshots:
       '@types/tough-cookie': 4.0.5
       axios: 1.13.2(debug@4.4.3)
       camelcase: 6.3.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@10.0.0)
       dotenv: 16.6.1
       extend: 3.0.2
       file-type: 16.5.4
@@ -17530,28 +17245,6 @@ snapshots:
       - web-tree-sitter
       - zod
 
-  llamaindex@0.12.1(@modelcontextprotocol/sdk@1.25.2(@cfworker/json-schema@4.1.1)(hono@4.11.4)(zod@3.25.76))(hono@4.11.4)(p-retry@6.2.1)(rxjs@7.8.2)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@3.25.76):
-    dependencies:
-      '@llamaindex/core': 0.6.22
-      '@llamaindex/env': 0.1.30
-      '@llamaindex/node-parser': 2.0.22(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)
-      '@llamaindex/workflow': 1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.25.2(@cfworker/json-schema@4.1.1)(hono@4.11.4)(zod@3.25.76))(hono@4.11.4)(p-retry@6.2.1)(rxjs@7.8.2)(zod@3.25.76)
-      '@types/lodash': 4.17.20
-      '@types/node': 24.0.15
-      lodash: 4.17.21
-      magic-bytes.js: 1.12.1
-    transitivePeerDependencies:
-      - '@huggingface/transformers'
-      - '@modelcontextprotocol/sdk'
-      - gpt-tokenizer
-      - hono
-      - next
-      - p-retry
-      - rxjs
-      - tree-sitter
-      - web-tree-sitter
-      - zod
-
   load-json-file@4.0.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -17932,14 +17625,6 @@ snapshots:
   neo-async@2.6.2: {}
 
   nocache@3.0.4: {}
-
-  nock@13.5.6:
-    dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-      json-stringify-safe: 5.0.1
-      propagate: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
 
   nock@13.5.6(supports-color@10.0.0):
     dependencies:
@@ -18892,14 +18577,6 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  require-in-the-middle@7.5.2:
-    dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-      module-details-from-path: 1.0.4
-      resolve: 1.22.10
-    transitivePeerDependencies:
-      - supports-color
-
   require-in-the-middle@7.5.2(supports-color@10.0.0):
     dependencies:
       debug: 4.4.3(supports-color@10.0.0)
@@ -18947,14 +18624,6 @@ snapshots:
       teeny-request: 9.0.0(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
-      - supports-color
-
-  retry-request@8.0.0:
-    dependencies:
-      '@types/request': 2.48.12
-      extend: 3.0.2
-      teeny-request: 10.1.0
-    transitivePeerDependencies:
       - supports-color
 
   retry-request@8.0.0(supports-color@10.0.0):
@@ -19011,16 +18680,6 @@ snapshots:
       fsevents: 2.3.3
 
   route-recognizer@0.3.4: {}
-
-  router@2.2.0:
-    dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-      depd: 2.0.0
-      is-promise: 4.0.0
-      parseurl: 1.3.3
-      path-to-regexp: 8.3.0
-    transitivePeerDependencies:
-      - supports-color
 
   router@2.2.0(supports-color@10.0.0):
     dependencies:
@@ -19084,22 +18743,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  send@1.2.0:
-    dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      fresh: 2.0.0
-      http-errors: 2.0.0
-      mime-types: 3.0.2
-      ms: 2.1.3
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      statuses: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
-
   send@1.2.0(supports-color@10.0.0):
     dependencies:
       debug: 4.4.3(supports-color@10.0.0)
@@ -19126,15 +18769,6 @@ snapshots:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.0(supports-color@10.0.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  serve-static@2.2.0:
-    dependencies:
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      parseurl: 1.3.3
-      send: 1.2.0
     transitivePeerDependencies:
       - supports-color
 
@@ -19217,7 +18851,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@10.0.0)
       socks: 2.8.6
     transitivePeerDependencies:
       - supports-color
@@ -19388,15 +19022,6 @@ snapshots:
       minizlib: 3.1.0
       yallist: 5.0.0
 
-  teeny-request@10.1.0:
-    dependencies:
-      http-proxy-agent: 5.0.0
-      https-proxy-agent: 5.0.1
-      node-fetch: 3.3.2
-      stream-events: 1.0.5
-    transitivePeerDependencies:
-      - supports-color
-
   teeny-request@10.1.0(supports-color@10.0.0):
     dependencies:
       http-proxy-agent: 5.0.0(supports-color@10.0.0)
@@ -19408,8 +19033,8 @@ snapshots:
 
   teeny-request@9.0.0(encoding@0.1.13):
     dependencies:
-      http-proxy-agent: 5.0.0
-      https-proxy-agent: 5.0.1
+      http-proxy-agent: 5.0.0(supports-color@10.0.0)
+      https-proxy-agent: 5.0.1(supports-color@10.0.0)
       node-fetch: 2.7.0(encoding@0.1.13)
       stream-events: 1.0.5
       uuid: 9.0.1
@@ -19570,7 +19195,7 @@ snapshots:
   tuf-js@4.1.0:
     dependencies:
       '@tufjs/models': 4.1.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@10.0.0)
       make-fetch-happen: 15.0.2
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
## Summary

Closes #58

- Removes `describe.skip` from `gemini.test.ts` and enables both Gemini `GenerativeModel` tests using Polly.js passthrough mode with route-level interceptors, so no real GCP credentials are needed in CI.
- **Bug fix**: `generationConfig` property names in the instrumentation were snake_case (`max_output_tokens`, `top_p`, `top_k`) but the `@google-cloud/vertexai` SDK uses camelCase (`maxOutputTokens`, `topP`, `topK`), so those span attributes were always `undefined`.
- Updates the test to use `vertexAI.getGenerativeModel()` (stable API) instead of `vertexAI.preview.getGenerativeModel()`, which returns `GenerativeModelPreview` — a separate, non-instrumented class.
- Adds Polly.js + `google-auth-library` as dev dependencies; stubs `GoogleAuth.prototype.getAccessToken` to return a fake token so no OAuth requests leave the process.
- Adds a comment to `palm2.test.ts` explaining why it stays skipped (gRPC transport + PaLM2 deprecation).

## Test plan

- [x] `pnpm nx test @traceloop/instrumentation-vertexai` — 2 passing, 2 pending (PaLM2 skipped)
- [x] `pnpm nx build @traceloop/instrumentation-vertexai` — clean build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected span attribute property names for Vertex AI generationConfig to use camelCase (`maxOutputTokens`, `topP`, `topK`).

* **Tests**
  * Enhanced Gemini instrumentation tests for non-streaming and streaming scenarios; added replayable HTTP/SSE recording fixtures and updated stream handling/assertions.
  * Clarified PaLM2 suite remains skipped.

* **Chores**
  * Added testing and auth-related dev dependencies to support HTTP/SSE interception and test harnessing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->