### PR TITLE
fix(evaluator): Update routes url

### DIFF
--- a/packages/traceloop-sdk/src/lib/client/evaluator/evaluator.ts
+++ b/packages/traceloop-sdk/src/lib/client/evaluator/evaluator.ts
@@ -362,8 +362,14 @@ export class Evaluator extends BaseDatasetEntity {
   async triggerExperimentEvaluator(
     request: TriggerEvaluatorRequest,
   ): Promise<TriggerEvaluatorResponse> {
-    const { experimentId, experimentSlug, experimentRunId, taskId, evaluator, taskResult } =
-      request;
+    const {
+      experimentId,
+      experimentSlug,
+      experimentRunId,
+      taskId,
+      evaluator,
+      taskResult,
+    } = request;
 
     if (!experimentSlug || !taskResult) {
       throw new Error("experimentSlug, evaluator, and taskResult are required");

--- a/packages/traceloop-sdk/src/lib/client/evaluator/evaluator.ts
+++ b/packages/traceloop-sdk/src/lib/client/evaluator/evaluator.ts
@@ -322,6 +322,7 @@ export class Evaluator extends BaseDatasetEntity {
   ): Promise<ExecutionResponse[]> {
     const {
       experimentId,
+      experimentSlug,
       experimentRunId,
       taskId,
       taskResult,
@@ -333,6 +334,7 @@ export class Evaluator extends BaseDatasetEntity {
 
     const triggerResponse = await this.triggerExperimentEvaluator({
       experimentId,
+      experimentSlug,
       experimentRunId,
       taskId,
       evaluator,
@@ -360,11 +362,11 @@ export class Evaluator extends BaseDatasetEntity {
   async triggerExperimentEvaluator(
     request: TriggerEvaluatorRequest,
   ): Promise<TriggerEvaluatorResponse> {
-    const { experimentId, experimentRunId, taskId, evaluator, taskResult } =
+    const { experimentId, experimentSlug, experimentRunId, taskId, evaluator, taskResult } =
       request;
 
-    if (!experimentId || !taskResult) {
-      throw new Error("experimentId, evaluator, and taskResult are required");
+    if (!experimentSlug || !taskResult) {
+      throw new Error("experimentSlug, evaluator, and taskResult are required");
     }
 
     // Handle string, EvaluatorWithVersion, and EvaluatorWithConfig types
@@ -399,7 +401,7 @@ export class Evaluator extends BaseDatasetEntity {
     }
 
     const response = await this.client.post(
-      `/v2/experiments/${experimentId}/runs/${experimentRunId}/tasks/${taskId}`,
+      `/v2/experiments/${experimentSlug}/runs/${experimentRunId}/tasks/${taskId}`,
       payload,
     );
     const data = await this.handleResponse(response);

--- a/packages/traceloop-sdk/src/lib/client/evaluator/evaluator.ts
+++ b/packages/traceloop-sdk/src/lib/client/evaluator/evaluator.ts
@@ -225,7 +225,7 @@ export class Evaluator extends BaseDatasetEntity {
   ): Promise<EvaluatorExecuteResponse> {
     this.validateIdentifier(identifier);
     const response = await this.client.post(
-      `/v2/evaluators/${encodeURIComponent(identifier)}/executions`,
+      `/v2/evaluators/${encodeURIComponent(identifier)}/execute`,
       { input: options.input },
     );
     const data = await this.handleResponse(response);
@@ -398,7 +398,7 @@ export class Evaluator extends BaseDatasetEntity {
     }
 
     const response = await this.client.post(
-      `/v2/evaluators/slug/${evaluatorName}/execute`,
+      `/v2/experiments/${experimentId}/runs/${experimentRunId}/tasks/${taskId}`,
       payload,
     );
     const data = await this.handleResponse(response);

--- a/packages/traceloop-sdk/src/lib/client/evaluator/evaluator.ts
+++ b/packages/traceloop-sdk/src/lib/client/evaluator/evaluator.ts
@@ -388,6 +388,7 @@ export class Evaluator extends BaseDatasetEntity {
       experiment_id: experimentId,
       experiment_run_id: experimentRunId,
       evaluator_version: evaluatorVersion,
+      evaluator_slug: evaluatorName,
       task_id: taskId,
       input_schema_mapping: inputSchemaMapping,
     };

--- a/packages/traceloop-sdk/src/lib/client/experiment/experiment.ts
+++ b/packages/traceloop-sdk/src/lib/client/experiment/experiment.ts
@@ -248,7 +248,7 @@ export class Experiment {
     };
 
     const response = await this.client.post(
-      `/v2/experiments/${experimentSlug}/runs/${experimentRunId}/task`,
+      `/v2/experiments/${experimentSlug}/runs/${experimentRunId}/tasks`,
       body,
     );
 

--- a/packages/traceloop-sdk/src/lib/client/experiment/experiment.ts
+++ b/packages/traceloop-sdk/src/lib/client/experiment/experiment.ts
@@ -179,6 +179,7 @@ export class Experiment {
               const singleEvaluationResult =
                 await this.evaluator.runExperimentEvaluator({
                   experimentId: experimentResponse.experiment.id,
+                  experimentSlug: experimentSlug,
                   experimentRunId: experimentResponse.run.id,
                   taskId,
                   evaluator,

--- a/packages/traceloop-sdk/src/lib/interfaces/evaluator.interface.ts
+++ b/packages/traceloop-sdk/src/lib/interfaces/evaluator.interface.ts
@@ -10,6 +10,7 @@ export interface StreamEvent {
 
 export interface EvaluatorRunOptions {
   experimentId: string;
+  experimentSlug: string;
   experimentRunId?: string;
   taskId: string;
   taskResult: Record<string, any>;
@@ -29,6 +30,7 @@ export interface EvaluatorResult {
 
 export interface TriggerEvaluatorRequest {
   experimentId: string;
+  experimentSlug: string;
   experimentRunId?: string;
   taskId?: string;
   evaluator: EvaluatorDetails;

--- a/packages/traceloop-sdk/test/standalone-evaluators.test.ts
+++ b/packages/traceloop-sdk/test/standalone-evaluators.test.ts
@@ -804,7 +804,7 @@ describe("StandaloneEvaluators", () => {
   // ─── run ─────────────────────────────────────────────────────────────────────
 
   describe("run", () => {
-    it("should POST to /v2/evaluators/:id/executions and return result", async () => {
+    it("should POST to /v2/evaluators/:id/execute and return result", async () => {
       let capturedUrl: string | undefined;
       let capturedMethod: string | undefined;
       let capturedBody: string | undefined;
@@ -828,7 +828,7 @@ describe("StandaloneEvaluators", () => {
 
       assert.strictEqual(
         capturedUrl,
-        "https://api.traceloop.com/v2/evaluators/eval-123/executions",
+        "https://api.traceloop.com/v2/evaluators/eval-123/execute",
       );
       assert.strictEqual(capturedMethod, "POST");
       assert.strictEqual(result.executionId, "exec-abc");
@@ -858,7 +858,7 @@ describe("StandaloneEvaluators", () => {
 
       assert.strictEqual(
         capturedUrl,
-        "https://api.traceloop.com/v2/evaluators/quality-judge/executions",
+        "https://api.traceloop.com/v2/evaluators/quality-judge/execute",
       );
     });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated evaluator execution endpoint to use the new execute route.
  * Changed experiment task creation to the pluralized tasks route.
  * Trigger requests now include evaluator_slug and forward experimentSlug.

* **Breaking Changes**
  * SDK run/trigger options now require experimentSlug; update any calls to supply this field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->