### PR TITLE
feat(instrumentation-openai): use token usage values reported by provider when available

### DIFF
--- a/packages/instrumentation-openai/src/instrumentation.ts
+++ b/packages/instrumentation-openai/src/instrumentation.ts
@@ -473,6 +473,9 @@ export class OpenAIInstrumentation extends InstrumentationBase {
             arguments: chunk.choices[0].delta.function_call.arguments,
           };
         }
+        if (chunk.usage) {
+          result.usage = chunk.usage;
+        }
         for (const toolCall of chunk.choices[0]?.delta?.tool_calls ?? []) {
           if (
             (result.choices[0].message.tool_calls?.length ?? 0) <
@@ -515,7 +518,7 @@ export class OpenAIInstrumentation extends InstrumentationBase {
         this._addLogProbsEvent(span, result.choices[0].logprobs);
       }
 
-      if (this._config.enrichTokens) {
+      if ((result.usage === undefined) && (this._config.enrichTokens)) {
         let promptTokens = 0;
         for (const message of params.messages) {
           promptTokens +=

--- a/packages/sample-app/src/sample_openai_streaming.ts
+++ b/packages/sample-app/src/sample_openai_streaming.ts
@@ -12,13 +12,24 @@ async function create_joke() {
   const responseStream = await traceloop.withTask(
     { name: "joke_creation" },
     () => {
-      return openai.chat.completions.create({
-        model: "gpt-3.5-turbo",
-        messages: [
-          { role: "user", content: "Tell me a joke about opentelemetry" },
-        ],
-        stream: true,
-      });
+      if (process.env.OPENAI_ENABLE_STREAMING_OPTION_USAGE === "true") {
+        return openai.chat.completions.create({
+          model: "gpt-3.5-turbo",
+          messages: [
+            { role: "user", content: "Tell me a joke about opentelemetry" },
+          ],
+          stream: true,
+          stream_options: { "include_usage": true },
+        });
+      } else {
+        return openai.chat.completions.create({
+          model: "gpt-3.5-turbo",
+          messages: [
+            { role: "user", content: "Tell me a joke about opentelemetry" },
+          ],
+          stream: true,
+        });
+      }
     },
   );
   let result = "";


### PR DESCRIPTION
This PR addresses issue #940.

When `include_usage` is set to `true` in the `stream_options` of OpenAI, the last chunk of the stream contains the `usage` field, which contains tokens usage info. When the `usage` field is available in a chunk, it is passed to the `result` object. If no `usage` info were found, we fallback to the previous method, that is, estimating the number of tokens used.

This PR also modifies the openAI streaming example, to include the ability to enable the `include_usage` option. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token usage tracking for OpenAI streaming chat completions to accurately preserve usage data from streaming responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->