### PR TITLE
Docs: Document content-block-mapper.ts

### DIFF
--- a/packages/instrumentation-google-generativeai/src/content-block-mapper.ts
+++ b/packages/instrumentation-google-generativeai/src/content-block-mapper.ts
@@ -1,3 +1,4 @@
+/** Documents packages/instrumentation-google-generativeai/src/content-block-mapper.ts module purpose and public usage context */
 /*
  * Copyright Traceloop
  *


### PR DESCRIPTION
Documents packages/instrumentation-google-generativeai/src/content-block-mapper.ts module purpose and public usage context