### PR TITLE
fix(openai): instrument Responses API

### DIFF
--- a/packages/instrumentation-openai/src/instrumentation.ts
+++ b/packages/instrumentation-openai/src/instrumentation.ts
@@ -364,7 +364,7 @@ export class OpenAIInstrumentation extends InstrumentationBase {
 
         const isStream = (args[0] as { stream?: boolean } | undefined)?.stream;
 
-        if (type === "responses") {
+        if (type === RESPONSES_TYPE) {
           if (isStream) {
             // Streaming for Responses API is not yet instrumented — close the
             // span with request attributes only. Hook the promise so a failed
@@ -386,7 +386,7 @@ export class OpenAIInstrumentation extends InstrumentationBase {
             return context.bind(execContext, execPromise);
           }
           const wrappedPromise = plugin._wrapPromise(
-            "responses",
+            RESPONSES_TYPE,
             version,
             span,
             execPromise,
@@ -435,12 +435,12 @@ export class OpenAIInstrumentation extends InstrumentationBase {
           client: any;
         }
       | {
-          type: "responses";
+          type: ResponsesType;
           params: ResponsesCreateParams;
           client: unknown;
         },
   ): Span {
-    if (args.type === "responses") {
+    if (args.type === RESPONSES_TYPE) {
       return this._startResponsesSpan(args.params, args.client);
     }
     const { type, params, client } = args;
@@ -793,15 +793,15 @@ export class OpenAIInstrumentation extends InstrumentationBase {
     type:
       | typeof GEN_AI_OPERATION_NAME_VALUE_CHAT
       | typeof GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION
-      | "responses",
+      | ResponsesType,
     version: "v3" | "v4",
     span: Span,
     promise: APIPromiseType<T>,
   ): APIPromiseType<T> {
     return promise._thenUnwrap((result) => {
-      if (type === "responses") {
+      if (type === RESPONSES_TYPE) {
         this._endSpan({
-          type: "responses",
+          type: RESPONSES_TYPE,
           span,
           result: result as ResponsesResult,
         });
@@ -866,11 +866,11 @@ export class OpenAIInstrumentation extends InstrumentationBase {
       }
     | {
         span: Span;
-        type: "responses";
+        type: ResponsesType;
         result: ResponsesResult;
       }) {
     try {
-      if (type === "responses") {
+      if (type === RESPONSES_TYPE) {
         this._endResponsesSpan(span, result);
         return;
       }

--- a/packages/instrumentation-openai/src/instrumentation.ts
+++ b/packages/instrumentation-openai/src/instrumentation.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 import type * as openai from "openai";
-import { context, trace, Span, Attributes, SpanKind } from "@opentelemetry/api";
+import {
+  context,
+  trace,
+  Span,
+  Attributes,
+  SpanKind,
+  SpanStatusCode,
+} from "@opentelemetry/api";
 import {
   InstrumentationBase,
   InstrumentationModuleDefinition,
@@ -107,6 +114,18 @@ import {
   wrapImageEdit,
   wrapImageVariation,
 } from "./image-wrappers";
+
+type ResponsesPrototype = {
+  prototype: { create: (...args: unknown[]) => unknown };
+};
+
+function getResponsesClass(
+  moduleExports: typeof openai,
+): ResponsesPrototype | undefined {
+  return (
+    moduleExports.OpenAI as unknown as { Responses?: ResponsesPrototype }
+  ).Responses;
+}
 
 export class OpenAIInstrumentation extends InstrumentationBase {
   declare protected _config: OpenAIInstrumentationConfig;
@@ -211,13 +230,7 @@ export class OpenAIInstrumentation extends InstrumentationBase {
         this.patchOpenAI(GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION),
       );
 
-      const Responses = (
-        moduleExports.OpenAI as unknown as {
-          Responses?: {
-            prototype: { create: (...args: unknown[]) => unknown };
-          };
-        }
-      ).Responses;
+      const Responses = getResponsesClass(moduleExports);
       if (Responses) {
         this._wrap(
           Responses.prototype,
@@ -276,13 +289,7 @@ export class OpenAIInstrumentation extends InstrumentationBase {
       this._unwrap(moduleExports.OpenAI.Chat.Completions.prototype, "create");
       this._unwrap(moduleExports.OpenAI.Completions.prototype, "create");
 
-      const Responses = (
-        moduleExports.OpenAI as unknown as {
-          Responses?: {
-            prototype: { create: (...args: unknown[]) => unknown };
-          };
-        }
-      ).Responses;
+      const Responses = getResponsesClass(moduleExports);
       if (Responses) {
         this._unwrap(Responses.prototype, "create");
       }
@@ -353,10 +360,23 @@ export class OpenAIInstrumentation extends InstrumentationBase {
 
         if (type === "responses") {
           if (isStream) {
-            // Streaming for Responses API is not yet instrumented — end the
-            // span with request attributes only so we don't leak it, and
-            // return the original stream untouched.
-            span.end();
+            // Streaming for Responses API is not yet instrumented — close the
+            // span with request attributes only. Hook the promise so a failed
+            // API call still records the error on the span before it exports,
+            // and a success closes cleanly. The original stream is returned
+            // untouched to the caller.
+            execPromise.then(
+              () => span.end(),
+              (err: unknown) => {
+                const e = err instanceof Error ? err : new Error(String(err));
+                span.recordException(e);
+                span.setStatus({
+                  code: SpanStatusCode.ERROR,
+                  message: e.message,
+                });
+                span.end();
+              },
+            );
             return context.bind(execContext, execPromise);
           }
           const wrappedPromise = plugin._wrapPromise(
@@ -514,13 +534,13 @@ export class OpenAIInstrumentation extends InstrumentationBase {
 
     try {
       attributes[ATTR_GEN_AI_REQUEST_MODEL] = params.model;
-      if (params.max_output_tokens) {
+      if (params.max_output_tokens != null) {
         attributes[ATTR_GEN_AI_REQUEST_MAX_TOKENS] = params.max_output_tokens;
       }
-      if (params.temperature) {
+      if (params.temperature != null) {
         attributes[ATTR_GEN_AI_REQUEST_TEMPERATURE] = params.temperature;
       }
-      if (params.top_p) {
+      if (params.top_p != null) {
         attributes[ATTR_GEN_AI_REQUEST_TOP_P] = params.top_p;
       }
 

--- a/packages/instrumentation-openai/src/instrumentation.ts
+++ b/packages/instrumentation-openai/src/instrumentation.ts
@@ -76,6 +76,32 @@ import { encodingForModel, TiktokenModel, Tiktoken } from "js-tiktoken";
 type APIPromiseType<T> = Promise<T> & {
   _thenUnwrap: <U>(onFulfilled: (value: T) => U) => APIPromiseType<U>;
 };
+
+// Minimal shape of the Responses API we touch. Defined locally rather than
+// imported from openai/resources/responses to keep this instrumentation
+// compatible with both v4 (no Responses) and v5+/v6 SDKs.
+interface ResponsesCreateParams {
+  model: string;
+  input: string | unknown[];
+  max_output_tokens?: number;
+  temperature?: number;
+  top_p?: number;
+  stream?: boolean;
+  extraAttributes?: Record<string, unknown>;
+}
+
+interface ResponsesResult {
+  id?: string;
+  model?: string;
+  output_text?: string;
+  status?: string;
+  incomplete_details?: { reason?: string } | null;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    total_tokens?: number;
+  };
+}
 import {
   wrapImageGeneration,
   wrapImageEdit,
@@ -185,12 +211,13 @@ export class OpenAIInstrumentation extends InstrumentationBase {
         this.patchOpenAI(GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION),
       );
 
-      if ((moduleExports.OpenAI as any).Responses) {
-        this._wrap(
-          (moduleExports.OpenAI as any).Responses.prototype,
-          "create",
-          this.patchOpenAI("responses"),
-        );
+      const Responses = (
+        moduleExports.OpenAI as unknown as {
+          Responses?: { prototype: { create: (...args: unknown[]) => unknown } };
+        }
+      ).Responses;
+      if (Responses) {
+        this._wrap(Responses.prototype, "create", this.patchOpenAI("responses"));
       }
 
       if (moduleExports.OpenAI.Images) {
@@ -243,11 +270,13 @@ export class OpenAIInstrumentation extends InstrumentationBase {
       this._unwrap(moduleExports.OpenAI.Chat.Completions.prototype, "create");
       this._unwrap(moduleExports.OpenAI.Completions.prototype, "create");
 
-      if ((moduleExports.OpenAI as any).Responses) {
-        this._unwrap(
-          (moduleExports.OpenAI as any).Responses.prototype,
-          "create",
-        );
+      const Responses = (
+        moduleExports.OpenAI as unknown as {
+          Responses?: { prototype: { create: (...args: unknown[]) => unknown } };
+        }
+      ).Responses;
+      if (Responses) {
+        this._unwrap(Responses.prototype, "create");
       }
 
       if (moduleExports.OpenAI.Images) {
@@ -282,7 +311,7 @@ export class OpenAIInstrumentation extends InstrumentationBase {
         } else if (type === "responses") {
           span = plugin.startSpan({
             type: "responses",
-            params: args[0] as any,
+            params: args[0] as ResponsesCreateParams,
             client: this,
           });
         } else {
@@ -312,7 +341,7 @@ export class OpenAIInstrumentation extends InstrumentationBase {
           },
         );
 
-        const isStream = (args[0] as any)?.stream;
+        const isStream = (args[0] as { stream?: boolean } | undefined)?.stream;
 
         if (type === "responses") {
           if (isStream) {
@@ -320,7 +349,7 @@ export class OpenAIInstrumentation extends InstrumentationBase {
             // span with request attributes only so we don't leak it, and
             // return the original stream untouched.
             span.end();
-            return context.bind(execContext, execPromise as any);
+            return context.bind(execContext, execPromise);
           }
           const wrappedPromise = plugin._wrapPromise(
             "responses",
@@ -328,7 +357,7 @@ export class OpenAIInstrumentation extends InstrumentationBase {
             span,
             execPromise,
           );
-          return context.bind(execContext, wrappedPromise as any);
+          return context.bind(execContext, wrappedPromise);
         }
 
         if (isStream) {
@@ -373,8 +402,8 @@ export class OpenAIInstrumentation extends InstrumentationBase {
         }
       | {
           type: "responses";
-          params: any;
-          client: any;
+          params: ResponsesCreateParams;
+          client: unknown;
         },
   ): Span {
     if (args.type === "responses") {
@@ -462,7 +491,10 @@ export class OpenAIInstrumentation extends InstrumentationBase {
     });
   }
 
-  private _startResponsesSpan(params: any, client: any): Span {
+  private _startResponsesSpan(
+    params: ResponsesCreateParams,
+    client: unknown,
+  ): Span {
     const { provider } = this._detectVendorFromURL(client);
 
     // Reuse `chat` operation name (and span name) — Responses API is the
@@ -488,8 +520,16 @@ export class OpenAIInstrumentation extends InstrumentationBase {
         params.extraAttributes !== undefined &&
         typeof params.extraAttributes === "object"
       ) {
-        Object.keys(params.extraAttributes).forEach((key: string) => {
-          attributes[key] = params.extraAttributes[key];
+        const extra = params.extraAttributes;
+        Object.keys(extra).forEach((key: string) => {
+          const v = extra[key];
+          if (
+            typeof v === "string" ||
+            typeof v === "number" ||
+            typeof v === "boolean"
+          ) {
+            attributes[key] = v;
+          }
         });
       }
 
@@ -726,7 +766,11 @@ export class OpenAIInstrumentation extends InstrumentationBase {
   ): APIPromiseType<T> {
     return promise._thenUnwrap((result) => {
       if (type === "responses") {
-        this._endSpan({ type: "responses", span, result: result as any });
+        this._endSpan({
+          type: "responses",
+          span,
+          result: result as ResponsesResult,
+        });
         return result;
       }
       if (version === "v3") {
@@ -789,7 +833,7 @@ export class OpenAIInstrumentation extends InstrumentationBase {
     | {
         span: Span;
         type: "responses";
-        result: any;
+        result: ResponsesResult;
       }) {
     try {
       if (type === "responses") {
@@ -858,7 +902,7 @@ export class OpenAIInstrumentation extends InstrumentationBase {
     span.end();
   }
 
-  private _endResponsesSpan(span: Span, result: any) {
+  private _endResponsesSpan(span: Span, result: ResponsesResult) {
     try {
       if (result.model) {
         span.setAttribute(ATTR_GEN_AI_RESPONSE_MODEL, result.model);

--- a/packages/instrumentation-openai/src/instrumentation.ts
+++ b/packages/instrumentation-openai/src/instrumentation.ts
@@ -128,9 +128,8 @@ type ResponsesPrototype = {
 function getResponsesClass(
   moduleExports: typeof openai,
 ): ResponsesPrototype | undefined {
-  return (
-    moduleExports.OpenAI as unknown as { Responses?: ResponsesPrototype }
-  ).Responses;
+  return (moduleExports.OpenAI as unknown as { Responses?: ResponsesPrototype })
+    .Responses;
 }
 
 export class OpenAIInstrumentation extends InstrumentationBase {

--- a/packages/instrumentation-openai/src/instrumentation.ts
+++ b/packages/instrumentation-openai/src/instrumentation.ts
@@ -55,6 +55,7 @@ import {
   buildOpenAIInputMessages,
   buildOpenAIOutputMessage,
   buildOpenAICompletionOutputMessage,
+  buildOpenAIResponsesOutputMessage,
   openaiFinishReasonMap,
 } from "./message-helpers";
 import type {
@@ -107,6 +108,14 @@ export class OpenAIInstrumentation extends InstrumentationBase {
       "create",
       this.patchOpenAI(GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION),
     );
+
+    if (openaiModule.Responses) {
+      this._wrap(
+        openaiModule.Responses.prototype,
+        "create",
+        this.patchOpenAI("responses"),
+      );
+    }
 
     if (openaiModule.Images) {
       this._wrap(
@@ -176,6 +185,14 @@ export class OpenAIInstrumentation extends InstrumentationBase {
         this.patchOpenAI(GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION),
       );
 
+      if ((moduleExports.OpenAI as any).Responses) {
+        this._wrap(
+          (moduleExports.OpenAI as any).Responses.prototype,
+          "create",
+          this.patchOpenAI("responses"),
+        );
+      }
+
       if (moduleExports.OpenAI.Images) {
         this._wrap(
           moduleExports.OpenAI.Images.prototype,
@@ -226,6 +243,13 @@ export class OpenAIInstrumentation extends InstrumentationBase {
       this._unwrap(moduleExports.OpenAI.Chat.Completions.prototype, "create");
       this._unwrap(moduleExports.OpenAI.Completions.prototype, "create");
 
+      if ((moduleExports.OpenAI as any).Responses) {
+        this._unwrap(
+          (moduleExports.OpenAI as any).Responses.prototype,
+          "create",
+        );
+      }
+
       if (moduleExports.OpenAI.Images) {
         this._unwrap(moduleExports.OpenAI.Images.prototype, "generate");
         this._unwrap(moduleExports.OpenAI.Images.prototype, "edit");
@@ -237,7 +261,8 @@ export class OpenAIInstrumentation extends InstrumentationBase {
   private patchOpenAI(
     type:
       | typeof GEN_AI_OPERATION_NAME_VALUE_CHAT
-      | typeof GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION,
+      | typeof GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION
+      | "responses",
     version: "v3" | "v4" = "v4",
   ) {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
@@ -245,22 +270,30 @@ export class OpenAIInstrumentation extends InstrumentationBase {
     // eslint-disable-next-line
     return (original: Function) => {
       return function method(this: any, ...args: unknown[]) {
-        const span =
-          type === GEN_AI_OPERATION_NAME_VALUE_CHAT
-            ? plugin.startSpan({
-                type,
-                params: args[0] as ChatCompletionCreateParamsNonStreaming & {
-                  extraAttributes?: Record<string, any>;
-                },
-                client: this,
-              })
-            : plugin.startSpan({
-                type: GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION,
-                params: args[0] as CompletionCreateParamsNonStreaming & {
-                  extraAttributes?: Record<string, any>;
-                },
-                client: this,
-              });
+        let span: Span;
+        if (type === GEN_AI_OPERATION_NAME_VALUE_CHAT) {
+          span = plugin.startSpan({
+            type,
+            params: args[0] as ChatCompletionCreateParamsNonStreaming & {
+              extraAttributes?: Record<string, any>;
+            },
+            client: this,
+          });
+        } else if (type === "responses") {
+          span = plugin.startSpan({
+            type: "responses",
+            params: args[0] as any,
+            client: this,
+          });
+        } else {
+          span = plugin.startSpan({
+            type: GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION,
+            params: args[0] as CompletionCreateParamsNonStreaming & {
+              extraAttributes?: Record<string, any>;
+            },
+            client: this,
+          });
+        }
 
         const execContext = trace.setSpan(context.active(), span);
         const execPromise = safeExecuteInTheMiddle(
@@ -279,13 +312,26 @@ export class OpenAIInstrumentation extends InstrumentationBase {
           },
         );
 
-        if (
-          (
-            args[0] as
-              | ChatCompletionCreateParamsStreaming
-              | CompletionCreateParamsStreaming
-          ).stream
-        ) {
+        const isStream = (args[0] as any)?.stream;
+
+        if (type === "responses") {
+          if (isStream) {
+            // Streaming for Responses API is not yet instrumented — end the
+            // span with request attributes only so we don't leak it, and
+            // return the original stream untouched.
+            span.end();
+            return context.bind(execContext, execPromise as any);
+          }
+          const wrappedPromise = plugin._wrapPromise(
+            "responses",
+            version,
+            span,
+            execPromise,
+          );
+          return context.bind(execContext, wrappedPromise as any);
+        }
+
+        if (isStream) {
           return context.bind(
             execContext,
             plugin._streamingWrapPromise({
@@ -309,25 +355,32 @@ export class OpenAIInstrumentation extends InstrumentationBase {
     };
   }
 
-  private startSpan({
-    type,
-    params,
-    client,
-  }:
-    | {
-        type: typeof GEN_AI_OPERATION_NAME_VALUE_CHAT;
-        params: ChatCompletionCreateParamsNonStreaming & {
-          extraAttributes?: Record<string, any>;
-        };
-        client: any;
-      }
-    | {
-        type: typeof GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION;
-        params: CompletionCreateParamsNonStreaming & {
-          extraAttributes?: Record<string, any>;
-        };
-        client: any;
-      }): Span {
+  private startSpan(
+    args:
+      | {
+          type: typeof GEN_AI_OPERATION_NAME_VALUE_CHAT;
+          params: ChatCompletionCreateParamsNonStreaming & {
+            extraAttributes?: Record<string, any>;
+          };
+          client: any;
+        }
+      | {
+          type: typeof GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION;
+          params: CompletionCreateParamsNonStreaming & {
+            extraAttributes?: Record<string, any>;
+          };
+          client: any;
+        }
+      | {
+          type: "responses";
+          params: any;
+          client: any;
+        },
+  ): Span {
+    if (args.type === "responses") {
+      return this._startResponsesSpan(args.params, args.client);
+    }
+    const { type, params, client } = args;
     const { provider } = this._detectVendorFromURL(client);
 
     const attributes: Attributes = {
@@ -407,6 +460,60 @@ export class OpenAIInstrumentation extends InstrumentationBase {
       kind: SpanKind.CLIENT,
       attributes,
     });
+  }
+
+  private _startResponsesSpan(params: any, client: any): Span {
+    const { provider } = this._detectVendorFromURL(client);
+
+    // Reuse `chat` operation name (and span name) — Responses API is the
+    // chat surface from the OTel gen_ai perspective.
+    const attributes: Attributes = {
+      [ATTR_GEN_AI_PROVIDER_NAME]: provider,
+      [ATTR_GEN_AI_OPERATION_NAME]: GEN_AI_OPERATION_NAME_VALUE_CHAT,
+    };
+
+    try {
+      attributes[ATTR_GEN_AI_REQUEST_MODEL] = params.model;
+      if (params.max_output_tokens) {
+        attributes[ATTR_GEN_AI_REQUEST_MAX_TOKENS] = params.max_output_tokens;
+      }
+      if (params.temperature) {
+        attributes[ATTR_GEN_AI_REQUEST_TEMPERATURE] = params.temperature;
+      }
+      if (params.top_p) {
+        attributes[ATTR_GEN_AI_REQUEST_TOP_P] = params.top_p;
+      }
+
+      if (
+        params.extraAttributes !== undefined &&
+        typeof params.extraAttributes === "object"
+      ) {
+        Object.keys(params.extraAttributes).forEach((key: string) => {
+          attributes[key] = params.extraAttributes[key];
+        });
+      }
+
+      if (this._shouldSendPrompts()) {
+        const text =
+          typeof params.input === "string"
+            ? params.input
+            : JSON.stringify(params.input);
+        attributes[ATTR_GEN_AI_INPUT_MESSAGES] = JSON.stringify([
+          { role: "user", parts: [{ type: "text", content: text }] },
+        ]);
+      }
+    } catch (e) {
+      this._diag.debug(e);
+      this._config.exceptionLogger?.(e);
+    }
+
+    return this.tracer.startSpan(
+      `${GEN_AI_OPERATION_NAME_VALUE_CHAT} ${params?.model}`,
+      {
+        kind: SpanKind.CLIENT,
+        attributes,
+      },
+    );
   }
 
   private async *_streamingWrapPromise({
@@ -611,12 +718,17 @@ export class OpenAIInstrumentation extends InstrumentationBase {
   private _wrapPromise<T>(
     type:
       | typeof GEN_AI_OPERATION_NAME_VALUE_CHAT
-      | typeof GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION,
+      | typeof GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION
+      | "responses",
     version: "v3" | "v4",
     span: Span,
     promise: APIPromiseType<T>,
   ): APIPromiseType<T> {
     return promise._thenUnwrap((result) => {
+      if (type === "responses") {
+        this._endSpan({ type: "responses", span, result: result as any });
+        return result;
+      }
       if (version === "v3") {
         if (type === GEN_AI_OPERATION_NAME_VALUE_CHAT) {
           this._addLogProbsEvent(
@@ -673,8 +785,17 @@ export class OpenAIInstrumentation extends InstrumentationBase {
         span: Span;
         type: typeof GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION;
         result: Completion;
+      }
+    | {
+        span: Span;
+        type: "responses";
+        result: any;
       }) {
     try {
+      if (type === "responses") {
+        this._endResponsesSpan(span, result);
+        return;
+      }
       span.setAttribute(ATTR_GEN_AI_RESPONSE_MODEL, result.model);
       if (result.id) {
         span.setAttribute(ATTR_GEN_AI_RESPONSE_ID, result.id);
@@ -728,6 +849,57 @@ export class OpenAIInstrumentation extends InstrumentationBase {
             JSON.stringify(outputMessages),
           );
         }
+      }
+    } catch (e) {
+      this._diag.debug(e);
+      this._config.exceptionLogger?.(e);
+    }
+
+    span.end();
+  }
+
+  private _endResponsesSpan(span: Span, result: any) {
+    try {
+      if (result.model) {
+        span.setAttribute(ATTR_GEN_AI_RESPONSE_MODEL, result.model);
+      }
+      if (result.id) {
+        span.setAttribute(ATTR_GEN_AI_RESPONSE_ID, result.id);
+      }
+      if (result.usage) {
+        const inputTokens = result.usage.input_tokens;
+        const outputTokens = result.usage.output_tokens;
+        if (typeof inputTokens === "number") {
+          span.setAttribute(ATTR_GEN_AI_USAGE_INPUT_TOKENS, inputTokens);
+        }
+        if (typeof outputTokens === "number") {
+          span.setAttribute(ATTR_GEN_AI_USAGE_OUTPUT_TOKENS, outputTokens);
+        }
+        const totalTokens =
+          typeof result.usage.total_tokens === "number"
+            ? result.usage.total_tokens
+            : typeof inputTokens === "number" &&
+                typeof outputTokens === "number"
+              ? inputTokens + outputTokens
+              : undefined;
+        if (typeof totalTokens === "number") {
+          span.setAttribute(
+            SpanAttributes.GEN_AI_USAGE_TOTAL_TOKENS,
+            totalTokens,
+          );
+        }
+      }
+
+      const outputMessages = buildOpenAIResponsesOutputMessage(result);
+      span.setAttribute(
+        ATTR_GEN_AI_RESPONSE_FINISH_REASONS,
+        [outputMessages[0].finish_reason],
+      );
+      if (this._shouldSendPrompts()) {
+        span.setAttribute(
+          ATTR_GEN_AI_OUTPUT_MESSAGES,
+          JSON.stringify(outputMessages),
+        );
       }
     } catch (e) {
       this._diag.debug(e);

--- a/packages/instrumentation-openai/src/instrumentation.ts
+++ b/packages/instrumentation-openai/src/instrumentation.ts
@@ -213,11 +213,17 @@ export class OpenAIInstrumentation extends InstrumentationBase {
 
       const Responses = (
         moduleExports.OpenAI as unknown as {
-          Responses?: { prototype: { create: (...args: unknown[]) => unknown } };
+          Responses?: {
+            prototype: { create: (...args: unknown[]) => unknown };
+          };
         }
       ).Responses;
       if (Responses) {
-        this._wrap(Responses.prototype, "create", this.patchOpenAI("responses"));
+        this._wrap(
+          Responses.prototype,
+          "create",
+          this.patchOpenAI("responses"),
+        );
       }
 
       if (moduleExports.OpenAI.Images) {
@@ -272,7 +278,9 @@ export class OpenAIInstrumentation extends InstrumentationBase {
 
       const Responses = (
         moduleExports.OpenAI as unknown as {
-          Responses?: { prototype: { create: (...args: unknown[]) => unknown } };
+          Responses?: {
+            prototype: { create: (...args: unknown[]) => unknown };
+          };
         }
       ).Responses;
       if (Responses) {
@@ -935,10 +943,9 @@ export class OpenAIInstrumentation extends InstrumentationBase {
       }
 
       const outputMessages = buildOpenAIResponsesOutputMessage(result);
-      span.setAttribute(
-        ATTR_GEN_AI_RESPONSE_FINISH_REASONS,
-        [outputMessages[0].finish_reason],
-      );
+      span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, [
+        outputMessages[0].finish_reason,
+      ]);
       if (this._shouldSendPrompts()) {
         span.setAttribute(
           ATTR_GEN_AI_OUTPUT_MESSAGES,

--- a/packages/instrumentation-openai/src/instrumentation.ts
+++ b/packages/instrumentation-openai/src/instrumentation.ts
@@ -84,6 +84,12 @@ type APIPromiseType<T> = Promise<T> & {
   _thenUnwrap: <U>(onFulfilled: (value: T) => U) => APIPromiseType<U>;
 };
 
+// Internal tag for the Responses API instrumentation path. Distinct from the
+// OTel `gen_ai.operation.name` value (which is still `"chat"`); this is only
+// used to discriminate the request/response shape inside this file.
+const RESPONSES_TYPE = "responses" as const;
+type ResponsesType = typeof RESPONSES_TYPE;
+
 // Minimal shape of the Responses API we touch. Defined locally rather than
 // imported from openai/resources/responses to keep this instrumentation
 // compatible with both v4 (no Responses) and v5+/v6 SDKs.
@@ -158,7 +164,7 @@ export class OpenAIInstrumentation extends InstrumentationBase {
       this._wrap(
         openaiModule.Responses.prototype,
         "create",
-        this.patchOpenAI("responses"),
+        this.patchOpenAI(RESPONSES_TYPE),
       );
     }
 
@@ -235,7 +241,7 @@ export class OpenAIInstrumentation extends InstrumentationBase {
         this._wrap(
           Responses.prototype,
           "create",
-          this.patchOpenAI("responses"),
+          this.patchOpenAI(RESPONSES_TYPE),
         );
       }
 
@@ -306,7 +312,7 @@ export class OpenAIInstrumentation extends InstrumentationBase {
     type:
       | typeof GEN_AI_OPERATION_NAME_VALUE_CHAT
       | typeof GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION
-      | "responses",
+      | ResponsesType,
     version: "v3" | "v4" = "v4",
   ) {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
@@ -323,9 +329,9 @@ export class OpenAIInstrumentation extends InstrumentationBase {
             },
             client: this,
           });
-        } else if (type === "responses") {
+        } else if (type === RESPONSES_TYPE) {
           span = plugin.startSpan({
-            type: "responses",
+            type: RESPONSES_TYPE,
             params: args[0] as ResponsesCreateParams,
             client: this,
           });

--- a/packages/instrumentation-openai/src/message-helpers.ts
+++ b/packages/instrumentation-openai/src/message-helpers.ts
@@ -288,6 +288,41 @@ export function buildOpenAIOutputMessage(
 }
 
 /**
+ * Assembles an OTel output message from an OpenAI Responses API response.
+ *
+ * The Responses API returns text via `result.output_text` (a convenience
+ * aggregator over `result.output[]`). Finish reason is derived from
+ * `result.status` — "completed" → stop, "incomplete" + max_output_tokens
+ * → length, otherwise pass through.
+ *
+ * @param result - The Responses API Response object
+ * @returns Array with a single OTelOutputMessage
+ */
+export function buildOpenAIResponsesOutputMessage(
+  result: any,
+): OTelOutputMessage[] {
+  let finishReason: string = FinishReasons.STOP;
+  if (result.status === "completed") {
+    finishReason = FinishReasons.STOP;
+  } else if (result.status === "incomplete") {
+    finishReason =
+      result.incomplete_details?.reason === "max_output_tokens"
+        ? FinishReasons.LENGTH
+        : (result.incomplete_details?.reason ?? result.status);
+  } else if (result.status) {
+    finishReason = result.status;
+  }
+
+  return [
+    {
+      role: "assistant",
+      finish_reason: finishReason,
+      parts: [{ type: "text", content: result.output_text ?? "" }],
+    },
+  ];
+}
+
+/**
  * Assembles an OTel output message from an OpenAI text completion response.
  *
  * @param choice - A single Completion.Choice (has .text and .finish_reason)

--- a/packages/instrumentation-openai/src/message-helpers.ts
+++ b/packages/instrumentation-openai/src/message-helpers.ts
@@ -287,6 +287,12 @@ export function buildOpenAIOutputMessage(
   ];
 }
 
+interface OpenAIResponsesResult {
+  status?: string;
+  output_text?: string;
+  incomplete_details?: { reason?: string } | null;
+}
+
 /**
  * Assembles an OTel output message from an OpenAI Responses API response.
  *
@@ -299,7 +305,7 @@ export function buildOpenAIOutputMessage(
  * @returns Array with a single OTelOutputMessage
  */
 export function buildOpenAIResponsesOutputMessage(
-  result: any,
+  result: OpenAIResponsesResult,
 ): OTelOutputMessage[] {
   let finishReason: string = FinishReasons.STOP;
   if (result.status === "completed") {

--- a/packages/instrumentation-openai/src/message-helpers.ts
+++ b/packages/instrumentation-openai/src/message-helpers.ts
@@ -297,9 +297,9 @@ interface OpenAIResponsesResult {
  * Assembles an OTel output message from an OpenAI Responses API response.
  *
  * The Responses API returns text via `result.output_text` (a convenience
- * aggregator over `result.output[]`). Finish reason is derived from
- * `result.status` — "completed" → stop, "incomplete" + max_output_tokens
- * → length, otherwise pass through.
+ * aggregator over `result.output[]`). Finish reason is mapped into the
+ * standardized OTel gen_ai.response.finish_reasons enum so downstream
+ * dashboards can filter without per-status special cases.
  *
  * @param result - The Responses API Response object
  * @returns Array with a single OTelOutputMessage
@@ -311,12 +311,16 @@ export function buildOpenAIResponsesOutputMessage(
   if (result.status === "completed") {
     finishReason = FinishReasons.STOP;
   } else if (result.status === "incomplete") {
-    finishReason =
-      result.incomplete_details?.reason === "max_output_tokens"
-        ? FinishReasons.LENGTH
-        : (result.incomplete_details?.reason ?? result.status);
-  } else if (result.status) {
-    finishReason = result.status;
+    const reason = result.incomplete_details?.reason;
+    if (reason === "max_output_tokens") {
+      finishReason = FinishReasons.LENGTH;
+    } else if (reason === "content_filter") {
+      finishReason = FinishReasons.CONTENT_FILTER;
+    } else {
+      finishReason = FinishReasons.ERROR;
+    }
+  } else if (result.status === "failed" || result.status === "cancelled") {
+    finishReason = FinishReasons.ERROR;
   }
 
   return [

--- a/packages/instrumentation-openai/test/instrumentation.test.ts
+++ b/packages/instrumentation-openai/test/instrumentation.test.ts
@@ -227,10 +227,9 @@ describe("Test OpenAI instrumentation", async function () {
 
     assert.ok(span.attributes[ATTR_GEN_AI_USAGE_INPUT_TOKENS]);
     assert.ok(+span.attributes[ATTR_GEN_AI_USAGE_OUTPUT_TOKENS]! > 0);
-    assert.deepEqual(
-      span.attributes[ATTR_GEN_AI_RESPONSE_FINISH_REASONS],
-      ["stop"],
-    );
+    assert.deepEqual(span.attributes[ATTR_GEN_AI_RESPONSE_FINISH_REASONS], [
+      "stop",
+    ]);
   });
 
   it("should set attributes in span for streaming chat", async () => {

--- a/packages/instrumentation-openai/test/instrumentation.test.ts
+++ b/packages/instrumentation-openai/test/instrumentation.test.ts
@@ -193,7 +193,7 @@ describe("Test OpenAI instrumentation", async function () {
   });
 
   it("should set attributes in span for responses (non-streaming)", async () => {
-    const result = await (openai as any).responses.create({
+    const result = await openai.responses.create({
       model: "gpt-4o-mini",
       input: "Tell me a joke about OpenTelemetry",
     });

--- a/packages/instrumentation-openai/test/instrumentation.test.ts
+++ b/packages/instrumentation-openai/test/instrumentation.test.ts
@@ -192,6 +192,47 @@ describe("Test OpenAI instrumentation", async function () {
     assert.ok(+completionSpan.attributes[ATTR_GEN_AI_USAGE_OUTPUT_TOKENS]! > 0);
   });
 
+  it("should set attributes in span for responses (non-streaming)", async () => {
+    const result = await (openai as any).responses.create({
+      model: "gpt-4o-mini",
+      input: "Tell me a joke about OpenTelemetry",
+    });
+
+    const spans = memoryExporter.getFinishedSpans();
+    const span = spans.find((s) => s.name.startsWith("chat "));
+
+    assert.ok(result);
+    assert.ok(span);
+    assert.strictEqual(span.attributes[ATTR_GEN_AI_PROVIDER_NAME], "openai");
+    assert.strictEqual(span.attributes[ATTR_GEN_AI_OPERATION_NAME], "chat");
+    assert.strictEqual(
+      span.attributes[ATTR_GEN_AI_REQUEST_MODEL],
+      "gpt-4o-mini",
+    );
+
+    const inputMessages = JSON.parse(
+      span.attributes[ATTR_GEN_AI_INPUT_MESSAGES] as string,
+    );
+    assert.strictEqual(inputMessages[0].role, "user");
+    assert.strictEqual(
+      inputMessages[0].parts[0].content,
+      "Tell me a joke about OpenTelemetry",
+    );
+
+    const outputMessages = JSON.parse(
+      span.attributes[ATTR_GEN_AI_OUTPUT_MESSAGES] as string,
+    );
+    assert.strictEqual(outputMessages[0].role, "assistant");
+    assert.ok(outputMessages[0].parts[0].content);
+
+    assert.ok(span.attributes[ATTR_GEN_AI_USAGE_INPUT_TOKENS]);
+    assert.ok(+span.attributes[ATTR_GEN_AI_USAGE_OUTPUT_TOKENS]! > 0);
+    assert.deepEqual(
+      span.attributes[ATTR_GEN_AI_RESPONSE_FINISH_REASONS],
+      ["stop"],
+    );
+  });
+
   it("should set attributes in span for streaming chat", async () => {
     const stream = await openai.chat.completions.create({
       messages: [

--- a/packages/instrumentation-openai/test/recordings/Test-OpenAI-instrumentation_1770406427/should-set-attributes-in-span-for-responses-non-streaming_1229494740/recording.har
+++ b/packages/instrumentation-openai/test/recordings/Test-OpenAI-instrumentation_1770406427/should-set-attributes-in-span-for-responses-non-streaming_1229494740/recording.har
@@ -1,0 +1,235 @@
+{
+  "log": {
+    "_recordingName": "Test OpenAI instrumentation/should set attributes in span for responses (non-streaming)",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "c94800faf5cc7c077d6bd96c5e4196b9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 68,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "OpenAI/JS 6.32.0"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-stainless-arch",
+              "value": "arm64"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-stainless-lang",
+              "value": "js"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-stainless-os",
+              "value": "MacOS"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-stainless-package-version",
+              "value": "6.32.0"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-stainless-retry-count",
+              "value": "0"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-stainless-runtime",
+              "value": "node"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-stainless-runtime-version",
+              "value": "v22.22.1"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "68"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "api.openai.com"
+            }
+          ],
+          "headersSize": 603,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"model\":\"gpt-4o-mini\",\"input\":\"Tell me a joke about OpenTelemetry\"}"
+          },
+          "queryString": [],
+          "url": "https://api.openai.com/v1/responses"
+        },
+        "response": {
+          "bodySize": 999,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 999,
+            "text": "[\"H4sIAAAAAAAA/3VUTY+bMBC976+gXHppKkhoQnqp1D/QS6UeNhWamCHxxtiuP9JFq/3vHZtAIE1uMG/mzdcbvz0lScrr9GuSGrS6yrYllOtstcKyXOIqz7I15GVe1nm2yooy3y7Lcss2X4o8OGw2qzz9FCjU/gWZG2iUtNjbmUFwWFcQsHyz2W7XRQ==\",\"nq8iZh04b0MMU60WSH590B7Y6WCUl6GuBoTF3syF4PJAtjf6JYOGDk2Ir/GMQmn6IeC9TzxQ3qQuIorGqBApvRDR0Bj841GyrtIoQbiOwOxzFjEuB7KqRgdc2Gkkl9YZzxynpqf2Fl4r5Z32rnLqhP+DTilRMRBzulbVKEJPB+0WhVq0XPLFMlsWi2yzyMt0dDIQUk5D+2xkeY7j6Yc0rre1h8fbXa6xzsJ2tyvEAgDXZbNlyJqYL7K4TmPkQWvhgFfg0RojyJR0KK9FTQub0Q6jwlc3RkcHkFI5GMb7/HsGCnXQRu3vIJGIeH8du6TmdeKOmPyg3f5EgS06Q9ZBNMmeRHpKvE7+cncMntwkoLXgLOb9tpM7+R0ZeIsJd8mLty5hyotafnTJEWQtMPLvUmeA4S5NVHOhEeqMH9KxsPfL11hrapSI/YO1nCZJo3oaHKMTidyQRlDM9UKS649C072RbvGObgk6c+VtNZxkFZUw6oUm12pHlOyI1Qm7h5jBsMNebaT3qsVWma6XIo3OKjk7y7jzOP2BLlxc0yhzY7O+bcEMecfTtdCg66jYkLThODtUi+bMqV3Hh9NvwIteMyRFZXA6HYetDpfiozm/DOZS3aVcqquF6/9Ek9GvX8el4jOavbI8jpkuoea+vT45/YKOisqLG/VOpSNwlSj96moi3Gw06mmNxks2nHhacwt7MbyPPh7g2ACXs0emf+Ju7JOXa2wzLre+BmazVm/fruX6HnCPd5TEI2pHBy2uYJGNI6QLm22bLhVqcBDo35/e/wFGLMfqrgYAAA==\"]"
+          },
+          "cookies": [
+            {
+              "domain": "api.openai.com",
+              "expires": "2026-05-28T10:58:34.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "02CMVzrPPcxsao2auj7Q.td6y5xqLQct1DB7tKaLl4k-1779964112.2245798-1.0.1.1-_860cJD87skJAAopXuTNqG3gDJwgmToosZSk2A2M0buYkEKbkrrcoTevp7KzXDybXITcuQ1e_I4qK28SXaCjtL9YCEQ32342Qfs9dcXfV4a92acSpN1WqeSWqGV1k9lG"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 28 May 2026 10:28:34 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "cf-ray",
+              "value": "a02c92b568e47a08-TLV"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "X-Request-ID, CF-Ray, CF-Ray"
+            },
+            {
+              "name": "openai-organization",
+              "value": "traceloop"
+            },
+            {
+              "name": "openai-processing-ms",
+              "value": "1884"
+            },
+            {
+              "name": "openai-project",
+              "value": "proj_tzz1TbPPOXaf6j9tEkVUBIAa"
+            },
+            {
+              "name": "openai-version",
+              "value": "2020-10-01"
+            },
+            {
+              "name": "x-ratelimit-limit-requests",
+              "value": "30000"
+            },
+            {
+              "name": "x-ratelimit-limit-tokens",
+              "value": "150000000"
+            },
+            {
+              "name": "x-ratelimit-remaining-requests",
+              "value": "29999"
+            },
+            {
+              "name": "x-ratelimit-remaining-tokens",
+              "value": "149999965"
+            },
+            {
+              "name": "x-ratelimit-reset-requests",
+              "value": "2ms"
+            },
+            {
+              "name": "x-ratelimit-reset-tokens",
+              "value": "0s"
+            },
+            {
+              "name": "x-request-id",
+              "value": "req_d316447754b2412ea3db6327c8d438b3"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=02CMVzrPPcxsao2auj7Q.td6y5xqLQct1DB7tKaLl4k-1779964112.2245798-1.0.1.1-_860cJD87skJAAopXuTNqG3gDJwgmToosZSk2A2M0buYkEKbkrrcoTevp7KzXDybXITcuQ1e_I4qK28SXaCjtL9YCEQ32342Qfs9dcXfV4a92acSpN1WqeSWqGV1k9lG; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.openai.com; Expires=Thu, 28 May 2026 10:58:34 GMT"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
+            }
+          ],
+          "headersSize": 1146,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-05-28T10:28:31.988Z",
+        "time": 2834,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2834
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}


### PR DESCRIPTION
## Summary

- Patch `openai.responses.create` so structured-output calls produce a `chat <model>` span (operation `chat`, mirroring chat.completions).
- Captures `gen_ai.input.messages` from `params.input`, `gen_ai.output.messages` from `result.output_text`, token usage (`input_tokens` / `output_tokens` / `total_tokens`), `gen_ai.response.model` / `id`, and a finish reason derived from `result.status` (`completed` → `stop`, `incomplete` + `max_output_tokens` → `length`).
- Adds a registered prototype patch in `patch()`, `unpatch()`, and `manuallyInstrument()`, guarded with `if (... .Responses)` so older v4 SDKs don't break.
- New helper `buildOpenAIResponsesOutputMessage` in `message-helpers.ts`.
- Streaming (`stream: true`) is **out of scope** this pass; defensively, the span is ended with request-only attributes and the original stream is returned untouched (no leak, no crash).
- New test + recorded HAR fixture (`gpt-4o-mini`); existing 34 tests stay green (35 passing total).

## Test plan

- [x] Red: new test `should set attributes in span for responses (non-streaming)` failed before implementation (no span produced).
- [x] Green: with the patch in place and the HAR fixture recorded, the test asserts provider, operation, model, input/output messages, token usage, and finish reason all match.
- [x] Replay mode: test passes against the committed HAR with no API key.
- [x] Full suite: `pnpm nx test @traceloop/instrumentation-openai` — 35 passing, 0 failing.
- [x] No regressions in existing chat / completions / image / function-calling tests.
- [x] Lint: no new errors (existing `any` warnings unchanged).
- [x] Recording scrubbed — no `authorization` header, no API key, only the same `openai-organization` / `openai-project` response headers already present in every committed recording.

## Follow-ups (separate PRs)

- Streaming via `response.output_text.delta` events.
- `instructions` field → system message in `gen_ai.input.messages`.
- Array `input` (multimodal / multi-turn).
- Function tools + built-in tools (web_search, file_search, code_interpreter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Instrumentation now supports the OpenAI Responses API, capturing model, token usage (including derived total), finish reason, and input/output message attributes; supports prompt/input tracing and merging simple extra attributes.
  * Added output message builder for Responses results.

* **Behavior**
  * Non‑streaming Responses end spans on completion; streaming Responses skip per‑chunk instrumentation and end spans when the stream resolves.

* **Tests**
  * Added test validating non‑streaming Responses span attributes.

* **Chores**
  * Added HTTP recording for the new test.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traceloop/openllmetry-js/pull/1010?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

![Uploading image.png…]()
