### PR TITLE
fix(ci): publish with lerna from-package instead of from-git

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,4 +57,4 @@ jobs:
       - name: Build for Release
         run: pnpm nx run-many --target=build --parallel=3
       - name: Publish
-        run: pnpm lerna publish --no-private from-git --yes
+        run: pnpm lerna publish --no-private from-package --yes


### PR DESCRIPTION
## Summary
- `lerna publish from-git` only fires when HEAD is tagged with a release. After v0.27.0, only workflow/CI commits landed on `main` with no conventional-commit prefix touching packages, so `lerna version` skipped, HEAD stayed untagged, and the next release run published nothing — even though v0.27.0 itself never made it to npm.
- Switching to `from-package` compares each `package.json` version against npm and publishes anything missing. Self-healing for the current 0.27.0 gap and resilient against future no-op version steps.

## Test plan
- [ ] Re-run the Release workflow on `main` after merge; confirm the 16 packages at 0.27.0 publish to npm.
- [ ] Future releases that DO trigger a version bump should behave identically to before (lerna version cuts a new tag → from-package publishes the new versions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to optimize package publishing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->