### PR TITLE
fix(instrumentations): add cache token span attributes for OpenAI, Bedrock, Together AI, and Vertex AI

### DIFF
--- a/packages/instrumentation-anthropic/src/instrumentation.ts
+++ b/packages/instrumentation-anthropic/src/instrumentation.ts
@@ -533,13 +533,19 @@ export class AnthropicInstrumentation extends InstrumentationBase {
         span.setAttribute(ATTR_GEN_AI_USAGE_INPUT_TOKENS, totalInputTokens);
 
         // Cache token attributes (v1.40)
-        if (result.usage.cache_creation_input_tokens != null) {
+        if (
+          result.usage.cache_creation_input_tokens !== null &&
+          result.usage.cache_creation_input_tokens !== undefined
+        ) {
           span.setAttribute(
             ATTR_GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
             result.usage.cache_creation_input_tokens,
           );
         }
-        if (result.usage.cache_read_input_tokens != null) {
+        if (
+          result.usage.cache_read_input_tokens !== null &&
+          result.usage.cache_read_input_tokens !== undefined
+        ) {
           span.setAttribute(
             ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
             result.usage.cache_read_input_tokens,

--- a/packages/instrumentation-bedrock/recordings/Test-Anthropic-with-AWS-Bedrock-Instrumentation_3427560822/should-set-cache-tokens-in-span-for-Anthropic-messages-API-with-cached-tokens_3921807056/recording.har
+++ b/packages/instrumentation-bedrock/recordings/Test-Anthropic-with-AWS-Bedrock-Instrumentation_3427560822/should-set-cache-tokens-in-span-for-Anthropic-messages-API-with-cached-tokens_3921807056/recording.har
@@ -1,0 +1,58 @@
+{
+  "log": {
+    "_recordingName": "Test Anthropic with AWS Bedrock Instrumentation/should set cache tokens in span for Anthropic messages API with cached tokens",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "bedrock_anthropic_cache_001",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 120,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 0,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "text": "{\"anthropic_version\": \"bedrock-2023-05-31\", \"max_tokens\": 300, \"messages\": [{\"role\": \"user\", \"content\": \"What are the 4 cardinal directions?\"}]}"
+          },
+          "queryString": [],
+          "url": "https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-3-5-sonnet-20241022-v2-0/invoke"
+        },
+        "response": {
+          "bodySize": 384,
+          "content": {
+            "mimeType": "application/json",
+            "size": 384,
+            "text": "{\"id\": \"msg_bedrock_cache_test_001\", \"type\": \"message\", \"role\": \"assistant\", \"content\": [{\"type\": \"text\", \"text\": \"The 4 cardinal directions are: North, South, East, and West.\"}], \"model\": \"claude-3-5-sonnet-20241022\", \"stop_reason\": \"end_turn\", \"stop_sequence\": null, \"usage\": {\"input_tokens\": 10, \"cache_creation_input_tokens\": 8, \"cache_read_input_tokens\": 5, \"output_tokens\": 15}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ],
+          "headersSize": 0,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-01-01T00:00:00.000Z",
+        "time": 500,
+        "timings": {
+          "receive": 0,
+          "send": 0,
+          "wait": 500
+        }
+      }
+    ]
+  }
+}

--- a/packages/instrumentation-bedrock/src/instrumentation.ts
+++ b/packages/instrumentation-bedrock/src/instrumentation.ts
@@ -706,7 +706,7 @@ export class BedrockInstrumentation extends InstrumentationBase {
                 const cacheRead = usage["cache_read_input_tokens"];
                 const cacheCreation = usage["cache_creation_input_tokens"];
                 const totalInputTokens =
-                  inputTokens + cacheRead + cacheCreation;
+                  inputTokens + (cacheRead ?? 0) + (cacheCreation ?? 0);
                 return {
                   [ATTR_GEN_AI_USAGE_INPUT_TOKENS]: totalInputTokens,
                   [ATTR_GEN_AI_USAGE_OUTPUT_TOKENS]: usage["output_tokens"],

--- a/packages/instrumentation-bedrock/src/instrumentation.ts
+++ b/packages/instrumentation-bedrock/src/instrumentation.ts
@@ -703,8 +703,8 @@ export class BedrockInstrumentation extends InstrumentationBase {
             ? (() => {
                 const inputTokens = usage["input_tokens"] || 0;
                 const outputTokens = usage["output_tokens"] || 0;
-                const cacheRead = usage["cache_read_input_tokens"] || 0;
-                const cacheCreation = usage["cache_creation_input_tokens"] || 0;
+                const cacheRead = usage["cache_read_input_tokens"];
+                const cacheCreation = usage["cache_creation_input_tokens"];
                 const totalInputTokens =
                   inputTokens + cacheRead + cacheCreation;
                 return {

--- a/packages/instrumentation-google-generativeai/src/instrumentation.ts
+++ b/packages/instrumentation-google-generativeai/src/instrumentation.ts
@@ -495,7 +495,7 @@ export class GenAIInstrumentation extends InstrumentationBase {
           SpanAttributes.GEN_AI_USAGE_REASONING_TOKENS,
           reasoningTokens,
         );
-      if (cachedTokens != null)
+      if (cachedTokens !== null && cachedTokens !== undefined)
         span.setAttribute(
           ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
           cachedTokens,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache token metrics tracking and validation across Anthropic, Google Generative AI, and Bedrock integrations with stricter null/undefined checks.
  * Enhanced totalInputTokens calculation to accurately include cache-related token values.

* **Tests**
  * Added test recording for Bedrock cache token handling scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->